### PR TITLE
Display unit test execution time after pytest run

### DIFF
--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -29,4 +29,4 @@ jobs:
          flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
       - name: Test with pytest
         run: |
-         pipenv run pytest --duration=10
+         pipenv run pytest --durations=10


### PR DESCRIPTION
Allows us to detect unit tests that take too much time to run more easily.