### PR TITLE
Point georinex dependency to main georinex main branch commit

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ pandas = "^2.2.0"
 numpy = "^1.26.3"
 joblib = "^1.3.2"
 imohash = "^1.0.5"
-georinex = { git = "https://github.com/jtec/georinex.git", branch = "parse_blank_nav_message_fields" }
+georinex = { git = "https://github.com/geospace-code/georinex.git", rev = "95ef1d8e7150f998a1b5a429090cadb429128648" }
 flake8 = "^7.0.0"
 dotmap = "^1.3.30"
 pytest = "^8.0.0"


### PR DESCRIPTION
This PR uses the latest commit on https://github.com/geospace-code/georinex/commits/main/, with https://github.com/geospace-code/georinex/pull/101 merged, while waiting for a new release.