### PR TITLE
Run lint only on ubuntu, add mac os CI test stage

### DIFF
--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -60,12 +60,33 @@ jobs:
       - name: Create virtual environment with poetry
         run:
           poetry install
-      - name: Lint with flake8
+      - name: Test with pytest
         run: |
-          # stop the build if there are Python syntax errors or undefined names
-          poetry run flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
-          # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
-          poetry run flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
+          poetry run pytest --durations=10
+  macos-ci:
+    runs-on: macos-latest
+    strategy:
+      matrix:
+        python-version: [ "3.10.8" ]
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v4
+        with:
+          python-version: ${{ matrix.python-version }}
+      - uses: abatilo/actions-poetry@v2.0.0
+        with:
+          poetry-version: 1.7.1
+      - name: Cache Poetry
+        uses: actions/cache@v2
+        with:
+          path: |
+            ~/.local
+            ~/.cache/pypoetry
+          key: poetry-${{ runner.os }}-${{ hashFiles('**/poetry.lock') }}
+      - name: Create virtual environment with poetry
+        run:
+          poetry install
       - name: Test with pytest
         run: |
           poetry run pytest --durations=10


### PR DESCRIPTION
With this PR

- the linter is run only in the ubuntu CI stage - pretty sure it's not platform-dependent
- we have a Mac OS CI stage running pytest, useful for platform-dependent tests such as https://github.com/jtec/prx/blob/7d4fcd2e977146152a534c2eac2034daa28909ad/src/prx/test/test_helpers.py#L258