### PR TITLE
Speed up CI by running tests in parallel

### DIFF
--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -35,7 +35,7 @@ jobs:
          poetry run flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
       - name: Test with pytest
         run: |
-         poetry run pytest --durations=10
+         poetry run pytest pytest -n auto --dist=loadfile --durations=10
   windows-ci:
     runs-on: windows-latest
     strategy:
@@ -62,7 +62,7 @@ jobs:
           poetry install
       - name: Test with pytest
         run: |
-          poetry run pytest --durations=10
+          poetry run pytest pytest -n auto --dist=loadfile --durations=10
   macos-ci:
     runs-on: macos-latest
     strategy:
@@ -89,4 +89,4 @@ jobs:
           poetry install
       - name: Test with pytest
         run: |
-          poetry run pytest --durations=10
+          poetry run pytest pytest -n auto --dist=loadfile --durations=10

--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -35,7 +35,7 @@ jobs:
          poetry run flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
       - name: Test with pytest
         run: |
-         poetry run pytest pytest -n auto --dist=loadfile --durations=10
+         poetry run pytest -n auto --dist=loadfile --durations=10
   windows-ci:
     runs-on: windows-latest
     strategy:
@@ -62,7 +62,7 @@ jobs:
           poetry install
       - name: Test with pytest
         run: |
-          poetry run pytest pytest -n auto --dist=loadfile --durations=10
+          poetry run pytest -n auto --dist=loadfile --durations=10
   macos-ci:
     runs-on: macos-latest
     strategy:
@@ -89,4 +89,4 @@ jobs:
           poetry install
       - name: Test with pytest
         run: |
-          poetry run pytest pytest -n auto --dist=loadfile --durations=10
+          poetry run pytest -n auto --dist=loadfile --durations=10

--- a/poetry.lock
+++ b/poetry.lock
@@ -162,6 +162,20 @@ files = [
 test = ["pytest (>=6)"]
 
 [[package]]
+name = "execnet"
+version = "2.0.2"
+description = "execnet: rapid multi-Python deployment"
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "execnet-2.0.2-py3-none-any.whl", hash = "sha256:88256416ae766bc9e8895c76a87928c0012183da3cc4fc18016e6f050e025f41"},
+    {file = "execnet-2.0.2.tar.gz", hash = "sha256:cc59bc4423742fd71ad227122eb0dd44db51efb3dc4095b45ac9a08c770096af"},
+]
+
+[package.extras]
+testing = ["hatch", "pre-commit", "pytest", "tox"]
+
+[[package]]
 name = "flake8"
 version = "7.0.0"
 description = "the modular source code checker: pep8 pyflakes and co"
@@ -261,15 +275,15 @@ xarray = "*"
 
 [package.extras]
 io = ["psutil"]
-lint = ["flake8", "flake8-blind-except", "flake8-bugbear", "flake8-builtins", "mypy", "types-python-dateutil"]
-plot = ["cartopy", "matplotlib", "pymap3d", "seaborn"]
+lint = ["flake8", "flake8-blind-except", "flake8-bugbear", "flake8-builtins", "mypy"]
+plot = ["cartopy", "matplotlib", "pymap3d"]
 tests = ["pytest", "pytest-timeout"]
 
 [package.source]
 type = "git"
-url = "https://github.com/jtec/georinex.git"
-reference = "parse_blank_nav_message_fields"
-resolved_reference = "d131cc54a3e483d0b5759edbf612c73a6bdcd14e"
+url = "https://github.com/geospace-code/georinex.git"
+reference = "95ef1d8e7150f998a1b5a429090cadb429128648"
+resolved_reference = "95ef1d8e7150f998a1b5a429090cadb429128648"
 
 [[package]]
 name = "gitdb"
@@ -1047,6 +1061,26 @@ tomli = {version = ">=1.0.0", markers = "python_version < \"3.11\""}
 testing = ["argcomplete", "attrs (>=19.2.0)", "hypothesis (>=3.56)", "mock", "nose", "pygments (>=2.7.2)", "requests", "setuptools", "xmlschema"]
 
 [[package]]
+name = "pytest-xdist"
+version = "3.5.0"
+description = "pytest xdist plugin for distributed testing, most importantly across multiple CPUs"
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "pytest-xdist-3.5.0.tar.gz", hash = "sha256:cbb36f3d67e0c478baa57fa4edc8843887e0f6cfc42d677530a36d7472b32d8a"},
+    {file = "pytest_xdist-3.5.0-py3-none-any.whl", hash = "sha256:d075629c7e00b611df89f490a5063944bee7a4362a5ff11c7cc7824a03dfce24"},
+]
+
+[package.dependencies]
+execnet = ">=1.1"
+pytest = ">=6.2.0"
+
+[package.extras]
+psutil = ["psutil (>=3.0)"]
+setproctitle = ["setproctitle"]
+testing = ["filelock"]
+
+[[package]]
 name = "python-dateutil"
 version = "2.8.2"
 description = "Extensions to the standard Python datetime module"
@@ -1193,4 +1227,4 @@ viz = ["matplotlib", "nc-time-axis", "seaborn"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "9ea582d38d72da7c1e091af5b6955d637bbcce73125c58988d2abfebfd50f95d"
+content-hash = "081f90d72a4f9d714484243c91480f7dc5f643ad93f5477818f1a23ee960542e"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,6 +19,7 @@ pytest = "^8.0.0"
 gitpython = "^3.1.41"
 scipy = "^1.12.0"
 matplotlib = "^3.8.2"
+pytest-xdist = "^3.5.0"
 
 
 [build-system]


### PR DESCRIPTION
With this PR, tests are run in parallel (github actions run on machines with 4 cores), grouped by file, i.e. tests that are defined in the same file are run sequentially.

I tried doing `pytest -n auto` instead of `pytest -n auto --dist=loadfile` but ran into some issues caused by pytest fixtures setting up test inputs in the same directory, which is then being accessed by multiple processes in parallel.

We could use separate test directories, we would then lose disk caching (since caching  depends on file paths as well as file content hashes), negating some of the speedup we get from running tests in parallel.

The ubuntu pytest stage [takes](https://github.com/jtec/prx/actions/runs/8131245682/job/22220351272?pr=62) 2m01s with this change, compared to 4m00s [on main](https://github.com/jtec/prx/actions/runs/8129020800/job/22215599839).