### PR TITLE
Caching can be disabled with environment variable

### DIFF
--- a/src/prx/helpers.py
+++ b/src/prx/helpers.py
@@ -13,7 +13,7 @@ from functools import lru_cache
 
 import os
 
-disable_caching = os.environ.get('PRX_NO_CACHING', False)
+disable_caching = os.environ.get("PRX_NO_CACHING", False)
 disk_cache = joblib.Memory(Path(__file__).parent.joinpath("diskcache"), verbose=0)
 
 

--- a/src/prx/helpers.py
+++ b/src/prx/helpers.py
@@ -11,7 +11,9 @@ import georinex
 import imohash
 from functools import lru_cache
 
+import os
 
+disable_caching = os.environ.get('PRX_NO_CACHING', False)
 disk_cache = joblib.Memory(Path(__file__).parent.joinpath("diskcache"), verbose=0)
 
 
@@ -240,7 +242,7 @@ def constellation(satellite_id: str):
 
 
 def compute_sagnac_effect(sat_pos_m, rx_pos_m):
-    """compute the sagnac effect (effect of the Earth rotation during signal propagation°
+    """compute the Sagnac effect (effect of the Earth's rotation during signal propagation°
 
     Input:
     - sat_pos_m: satellite ECEF position. np.ndarray of shape (n, 3)
@@ -362,7 +364,12 @@ def is_sorted(iterable):
 def cache_call(func):
     @lru_cache
     @disk_cache.cache
-    def wrapper_cache_call(*args, **kwargs):
+    def wrapper_cached_call(*args, **kwargs):
         return func(*args, **kwargs)
 
-    return wrapper_cache_call
+    def wrapper_uncached_call(*args, **kwargs):
+        return func(*args, **kwargs)
+
+    if disable_caching:
+        return wrapper_uncached_call
+    return wrapper_cached_call

--- a/src/prx/helpers.py
+++ b/src/prx/helpers.py
@@ -1,4 +1,5 @@
 import platform
+import sys
 from pathlib import Path
 import logging
 from prx import constants
@@ -10,20 +11,19 @@ import joblib
 import georinex
 import imohash
 from functools import lru_cache
-
 import os
-
-disable_caching = os.environ.get("PRX_NO_CACHING", False)
-disk_cache = joblib.Memory(Path(__file__).parent.joinpath("diskcache"), verbose=0)
-
 
 logging.basicConfig(
     format="%(asctime)s,%(msecs)03d %(levelname)-8s [%(filename)s:%(lineno)d] %(message)s",
     datefmt="%Y-%m-%d:%H:%M:%S",
     level=logging.DEBUG,
 )
-
 log = logging.getLogger(__name__)
+
+disable_caching = os.environ.get("PRX_NO_CACHING", "False").lower() in ("true", "1")
+if disable_caching:
+    log.debug(f"Environment variable PRX_NO_CACHING is {disable_caching}")
+disk_cache = joblib.Memory(Path(__file__).parent.joinpath("diskcache"), verbose=0)
 
 
 def get_logger(label):

--- a/src/prx/helpers.py
+++ b/src/prx/helpers.py
@@ -1,5 +1,4 @@
 import platform
-import sys
 from pathlib import Path
 import logging
 from prx import constants
@@ -20,9 +19,19 @@ logging.basicConfig(
 )
 log = logging.getLogger(__name__)
 
-disable_caching = os.environ.get("PRX_NO_CACHING", "False").lower() in ("true", "1")
+
+def parse_boolean_env_variable(env_variable_name: str, value_if_not_set: bool):
+    var_string = os.environ.get(env_variable_name, None)
+    if var_string is None:
+        return value_if_not_set
+    var_string = var_string.lower().strip()
+    assert var_string in ("True", "true", "1", "False", "false", "0")
+    return var_string in ("True", "true", "1")
+
+
+disable_caching = parse_boolean_env_variable("PRX_NO_CACHING", False)
 if disable_caching:
-    log.debug(f"Environment variable PRX_NO_CACHING is {disable_caching}")
+    log.debug("Caching disabled by environment variable PRX_NO_CACHING")
 disk_cache = joblib.Memory(Path(__file__).parent.joinpath("diskcache"), verbose=0)
 
 

--- a/src/prx/helpers.py
+++ b/src/prx/helpers.py
@@ -21,6 +21,7 @@ log = logging.getLogger(__name__)
 
 
 def parse_boolean_env_variable(env_variable_name: str, value_if_not_set: bool):
+    # Based on https://stackoverflow.com/a/65407083/2567449
     var_string = os.environ.get(env_variable_name, None)
     if var_string is None:
         return value_if_not_set

--- a/src/prx/main.py
+++ b/src/prx/main.py
@@ -5,14 +5,12 @@ import georinex
 import pandas as pd
 import numpy as np
 import git
-import joblib
 
 from prx import atmospheric_corrections as atmo
 from prx.rinex_nav import nav_file_discovery
 from prx import constants, helpers, converters
 from prx.rinex_nav import evaluate as rinex_evaluate
-
-memory = joblib.Memory(Path(__file__).parent.joinpath("diskcache"), verbose=0)
+from prx.helpers import disk_cache
 
 log = helpers.get_logger(__name__)
 
@@ -186,7 +184,7 @@ def build_records(
     )
 
 
-@memory.cache
+@helpers.cache_call
 def _build_records_cached(
     rinex_3_obs_file,
     rinex_3_obs_file_hash,

--- a/src/prx/main.py
+++ b/src/prx/main.py
@@ -180,7 +180,8 @@ def build_records(
         helpers.hash_of_file_content(rinex_3_obs_file),
         rinex_3_ephemerides_file,
         helpers.hash_of_file_content(rinex_3_ephemerides_file),
-        approximate_receiver_ecef_position_m,
+        # Use a tuple here as caching expects an immutable type
+        tuple(approximate_receiver_ecef_position_m),
     )
 
 
@@ -192,6 +193,7 @@ def _build_records_cached(
     rinex_3_ephemerides_file_hash,
     approximate_receiver_ecef_position_m,
 ):
+    approximate_receiver_ecef_position_m = np.array(approximate_receiver_ecef_position_m)
     check_assumptions(rinex_3_obs_file, rinex_3_ephemerides_file)
     obs = helpers.parse_rinex_obs_file(rinex_3_obs_file)
 

--- a/src/prx/main.py
+++ b/src/prx/main.py
@@ -193,7 +193,9 @@ def _build_records_cached(
     rinex_3_ephemerides_file_hash,
     approximate_receiver_ecef_position_m,
 ):
-    approximate_receiver_ecef_position_m = np.array(approximate_receiver_ecef_position_m)
+    approximate_receiver_ecef_position_m = np.array(
+        approximate_receiver_ecef_position_m
+    )
     check_assumptions(rinex_3_obs_file, rinex_3_ephemerides_file)
     obs = helpers.parse_rinex_obs_file(rinex_3_obs_file)
 

--- a/src/prx/parse_rinex.py
+++ b/src/prx/parse_rinex.py
@@ -2,17 +2,14 @@ import georinex
 from pathlib import Path
 
 import pandas as pd
-import joblib
 from prx import helpers
 
 log = helpers.get_logger(__name__)
 
-memory = joblib.Memory(Path(__file__).parent.joinpath("diskcache"), verbose=0)
-
 
 # Can speed up RINEX parsing by using parsing results previously obtained and saved to disk.
 def load(rinex_file: Path):
-    @memory.cache
+    @helpers.cache_call
     def cached_load(rinex_file: Path, file_hash: str):
         log.info(f"Parsing {rinex_file} ...")
         helpers.repair_with_gfzrnx(rinex_file)

--- a/src/prx/rinex_nav/evaluate.py
+++ b/src/prx/rinex_nav/evaluate.py
@@ -1,16 +1,12 @@
-import math
 import pandas as pd
 import numpy as np
-from functools import lru_cache
 from pathlib import Path
-import joblib
 import scipy
 import georinex
 from prx import helpers
 from prx import constants
 
 
-memory = joblib.Memory(Path(__file__).parent.joinpath("diskcache"), verbose=0)
 log = helpers.get_logger(__name__)
 
 
@@ -21,16 +17,14 @@ consts = {
 
 
 def parse_rinex_nav_file(rinex_file: Path):
-    @lru_cache
-    @memory.cache
+    @helpers.cache_call
     def cached_parse(rinex_file: Path, file_hash: str):
         log.info(f"Parsing {rinex_file} ...")
         helpers.repair_with_gfzrnx(rinex_file)
         ds = georinex.load(rinex_file)
         return ds
 
-    @lru_cache
-    @memory.cache
+    @helpers.cache_call
     def cached_load(rinex_file: Path, file_hash: str):
         ds = cached_parse(rinex_file, file_hash)
         df = convert_nav_dataset_to_dataframe(ds)

--- a/src/prx/sp3/evaluate.py
+++ b/src/prx/sp3/evaluate.py
@@ -5,19 +5,16 @@ from scipy.interpolate import lagrange
 from numpy.polynomial.polynomial import Polynomial
 import georinex
 from pathlib import Path
-import joblib
 import matplotlib.pyplot as plt
 
 from prx import helpers
 from prx import constants
 
-memory = joblib.Memory(Path(__file__).parent.joinpath("diskcache"), verbose=0)
 log = helpers.get_logger(__name__)
 
 
 def parse_sp3_file(file_path: Path):
-    @lru_cache
-    @memory.cache
+    @helpers.cache_call
     def cached_load(file_path: Path, file_hash: str):
         log.info(f"Parsing {file_path} ...")
         parsed = georinex.load(file_path)

--- a/src/prx/sp3/evaluate.py
+++ b/src/prx/sp3/evaluate.py
@@ -1,4 +1,3 @@
-from functools import lru_cache
 import pandas as pd
 import numpy as np
 from scipy.interpolate import lagrange

--- a/src/prx/test/test_main.py
+++ b/src/prx/test/test_main.py
@@ -1,4 +1,3 @@
-import json
 import os
 from pathlib import Path
 import shutil
@@ -7,6 +6,7 @@ import subprocess
 import numpy as np
 import pandas as pd
 import pytest
+import cProfile as profiler
 
 from prx import helpers
 from prx import constants

--- a/src/prx/test/test_main.py
+++ b/src/prx/test/test_main.py
@@ -6,7 +6,6 @@ import subprocess
 import numpy as np
 import pandas as pd
 import pytest
-import cProfile as profiler
 
 from prx import helpers
 from prx import constants


### PR DESCRIPTION
With this PR, setting the environment variable `PRX_NO_CACHING=true` disables both RAM and disk caching. 

When running with caching, the time an operation (i.e. parse a RINEX file) takes depends on the overall order of previous operations, which makes benchmarking difficult. 

Out in the wild most observation files `prx` will encounter will also be seen only once by the tool, so the speed we get with caching is not what we will see in day to day operation. For this very reason we need to be able to switch off caching to get an idea of `prx`'s speed under real world conditions.

# Testing

Running ` PRX_NO_CACHING=True pytest -k test_spp_lsq --durations=10  --log-cli-level=DEBUG` yields 

`66.26s call     src/prx/test/test_main.py::test_spp_lsq`

Running ` PRX_NO_CACHING=False pytest -k test_spp_lsq --durations=10  --log-cli-level=DEBUG` yields 

`0.21s call     src/prx/test/test_main.py::test_spp_lsq`

the first time (cache was already populated from a previous run of the test).