### PR TITLE
Replaces flake8 by ruff

### DIFF
--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -30,6 +30,7 @@ jobs:
       - name: Run ruff
         run: |
          poetry run ruff check
+         poetry run ruff format
       - name: Test with pytest
         run: |
          poetry run pytest -n auto --dist=loadfile --durations=10

--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -29,8 +29,8 @@ jobs:
           poetry install
       - name: Run ruff
         run: |
-         poetry run ruff check
-         poetry run ruff format
+         poetry run ruff check --exit-non-zero-on-fix
+         poetry run ruff format --check
       - name: Test with pytest
         run: |
          poetry run pytest -n auto --dist=loadfile --durations=10

--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -27,12 +27,9 @@ jobs:
       - name: Create virtual environment with poetry
         run:
           poetry install
-      - name: Lint with flake8
+      - name: Run ruff
         run: |
-         # stop the build if there are Python syntax errors or undefined names
-         poetry run flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
-         # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
-         poetry run flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
+         poetry run ruff check
       - name: Test with pytest
         run: |
          poetry run pytest -n auto --dist=loadfile --durations=10

--- a/poetry.lock
+++ b/poetry.lock
@@ -1106,6 +1106,32 @@ files = [
 ]
 
 [[package]]
+name = "ruff"
+version = "0.3.3"
+description = "An extremely fast Python linter and code formatter, written in Rust."
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "ruff-0.3.3-py3-none-macosx_10_12_x86_64.macosx_11_0_arm64.macosx_10_12_universal2.whl", hash = "sha256:973a0e388b7bc2e9148c7f9be8b8c6ae7471b9be37e1cc732f8f44a6f6d7720d"},
+    {file = "ruff-0.3.3-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:cfa60d23269d6e2031129b053fdb4e5a7b0637fc6c9c0586737b962b2f834493"},
+    {file = "ruff-0.3.3-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:1eca7ff7a47043cf6ce5c7f45f603b09121a7cc047447744b029d1b719278eb5"},
+    {file = "ruff-0.3.3-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:e7d3f6762217c1da954de24b4a1a70515630d29f71e268ec5000afe81377642d"},
+    {file = "ruff-0.3.3-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:b24c19e8598916d9c6f5a5437671f55ee93c212a2c4c569605dc3842b6820386"},
+    {file = "ruff-0.3.3-py3-none-manylinux_2_17_ppc64.manylinux2014_ppc64.whl", hash = "sha256:5a6cbf216b69c7090f0fe4669501a27326c34e119068c1494f35aaf4cc683778"},
+    {file = "ruff-0.3.3-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:352e95ead6964974b234e16ba8a66dad102ec7bf8ac064a23f95371d8b198aab"},
+    {file = "ruff-0.3.3-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:8d6ab88c81c4040a817aa432484e838aaddf8bfd7ca70e4e615482757acb64f8"},
+    {file = "ruff-0.3.3-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:79bca3a03a759cc773fca69e0bdeac8abd1c13c31b798d5bb3c9da4a03144a9f"},
+    {file = "ruff-0.3.3-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:2700a804d5336bcffe063fd789ca2c7b02b552d2e323a336700abb8ae9e6a3f8"},
+    {file = "ruff-0.3.3-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:fd66469f1a18fdb9d32e22b79f486223052ddf057dc56dea0caaf1a47bdfaf4e"},
+    {file = "ruff-0.3.3-py3-none-musllinux_1_2_i686.whl", hash = "sha256:45817af234605525cdf6317005923bf532514e1ea3d9270acf61ca2440691376"},
+    {file = "ruff-0.3.3-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:0da458989ce0159555ef224d5b7c24d3d2e4bf4c300b85467b08c3261c6bc6a8"},
+    {file = "ruff-0.3.3-py3-none-win32.whl", hash = "sha256:f2831ec6a580a97f1ea82ea1eda0401c3cdf512cf2045fa3c85e8ef109e87de0"},
+    {file = "ruff-0.3.3-py3-none-win_amd64.whl", hash = "sha256:be90bcae57c24d9f9d023b12d627e958eb55f595428bafcb7fec0791ad25ddfc"},
+    {file = "ruff-0.3.3-py3-none-win_arm64.whl", hash = "sha256:0171aab5fecdc54383993389710a3d1227f2da124d76a2784a7098e818f92d61"},
+    {file = "ruff-0.3.3.tar.gz", hash = "sha256:38671be06f57a2f8aba957d9f701ea889aa5736be806f18c0cd03d6ff0cbca8d"},
+]
+
+[[package]]
 name = "scipy"
 version = "1.12.0"
 description = "Fundamental algorithms for scientific computing in Python"
@@ -1227,4 +1253,4 @@ viz = ["matplotlib", "nc-time-axis", "seaborn"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "081f90d72a4f9d714484243c91480f7dc5f643ad93f5477818f1a23ee960542e"
+content-hash = "d2fe6ffe47449c910f96adb1a53bc741ef48ecd2f6ce97cb7a0581e7dde23492"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,6 +20,7 @@ gitpython = "^3.1.41"
 scipy = "^1.12.0"
 matplotlib = "^3.8.2"
 pytest-xdist = "^3.5.0"
+ruff = "^0.3.3"
 
 
 [build-system]

--- a/src/prx/converters.py
+++ b/src/prx/converters.py
@@ -70,7 +70,7 @@ def file_exists_and_can_read_first_line(file: Path):
     try:
         with open(file) as f:
             return f.readline()
-    except UnicodeDecodeError as e_unicode:
+    except UnicodeDecodeError:
         return None
 
 

--- a/src/prx/helpers.py
+++ b/src/prx/helpers.py
@@ -229,15 +229,6 @@ def build_glonass_slot_dictionary(header_line):
 
 
 def satellite_id_2_system_time_scale(satellite_id):
-    constellation_2_system_time_scale = {
-        "G": "GPST",
-        "S": "SBAST",
-        "E": "GST",
-        "C": "BDT",
-        "R": "GLONASST",
-        "J": "QZSST",
-        "I": "IRNSST",
-    }
     assert (
         len(satellite_id) == 3
     ), f"Satellite ID unexpectedly not three characters long: {satellite_id}"
@@ -315,11 +306,7 @@ def compute_satellite_elevation_and_azimuth(sat_pos_ecef, receiver_pos_ecef):
         np.dot(unit_vector_rx_satellite_ecef, unit_e_ecef),
         np.dot(unit_vector_rx_satellite_ecef, unit_n_ecef),
     )
-    elevation_deg = np.rad2deg(elevation_rad)
 
-    up = receiver_pos_ecef / np.linalg.norm(receiver_pos_ecef)
-    angle_up_los_deg = np.rad2deg(np.arccos(np.dot(unit_vector_rx_satellite_ecef, up)))
-    elevation_deg_2 = 90 - angle_up_los_deg
     return elevation_rad, azimuth_rad
 
 

--- a/src/prx/json_example.py
+++ b/src/prx/json_example.py
@@ -16,11 +16,11 @@ def generate_example_file(
         os.remove(file_path)
     with open(file_path, "w", encoding="utf-8") as file:
         file.write(
-            "\u241E" + json.dumps(header, ensure_ascii=False, indent=indent) + "\n"
+            "\u241e" + json.dumps(header, ensure_ascii=False, indent=indent) + "\n"
         )
         for observation in observations:
             file.write(
-                "\u241E"
+                "\u241e"
                 + json.dumps(
                     fields_to_arrays(observation), ensure_ascii=False, indent=indent
                 )

--- a/src/prx/main.py
+++ b/src/prx/main.py
@@ -213,7 +213,7 @@ def _build_records_cached(
             str(row[3]),
         ]
 
-    flat_obs = flat_obs.apply(                  format_flat_rows, axis=1, result_type="expand")
+    flat_obs = flat_obs.apply(format_flat_rows, axis=1, result_type="expand")
     flat_obs = flat_obs.rename(
         columns={
             0: "time_of_reception_in_receiver_time",

--- a/src/prx/main.py
+++ b/src/prx/main.py
@@ -213,7 +213,7 @@ def _build_records_cached(
             str(row[3]),
         ]
 
-    flat_obs = flat_obs.apply(format_flat_rows, axis=1, result_type="expand")
+    flat_obs = flat_obs.apply(          format_flat_rows, axis=1, result_type="expand")
     flat_obs = flat_obs.rename(
         columns={
             0: "time_of_reception_in_receiver_time",

--- a/src/prx/main.py
+++ b/src/prx/main.py
@@ -10,7 +10,6 @@ from prx import atmospheric_corrections as atmo
 from prx.rinex_nav import nav_file_discovery
 from prx import constants, helpers, converters
 from prx.rinex_nav import evaluate as rinex_evaluate
-from prx.helpers import disk_cache
 
 log = helpers.get_logger(__name__)
 
@@ -23,9 +22,7 @@ def write_prx_file(
 ):
     output_writers = {"jsonseq": write_json_text_sequence_file, "csv": write_csv_file}
     if output_format not in output_writers.keys():
-        assert (
-            False
-        ), f"Output format {output_format} not supported,  we can do {list(output_writers.keys())}"
+        assert False, f"Output format {output_format} not supported,  we can do {list(output_writers.keys())}"
     output_writers[output_format](prx_header, prx_records, file_name_without_extension)
 
 
@@ -36,7 +33,7 @@ def write_json_text_sequence_file(
         f"{str(file_name_without_extension)}.{constants.cPrxJsonTextSequenceFileExtension}"
     )
     with open(output_file, "w", encoding="utf-8") as file:
-        file.write("\u241E" + json.dumps(prx_header, ensure_ascii=False) + "\n")
+        file.write("\u241e" + json.dumps(prx_header, ensure_ascii=False) + "\n")
         drop_columns = [
             "time_of_reception_in_receiver_time",
             "satellite",
@@ -68,7 +65,7 @@ def write_json_text_sequence_file(
                     if type(row[col].values[0]) is np.ndarray:
                         row[col].values[0] = row[col].values[0].tolist()
                     record["satellites"][sat][col] = row[col].values[0]
-            file.write("\u241E" + json.dumps(record, ensure_ascii=False) + "\n")
+            file.write("\u241e" + json.dumps(record, ensure_ascii=False) + "\n")
     log.info(f"Generated JSON Text Sequence prx file: {output_file}")
 
 
@@ -199,14 +196,6 @@ def _build_records_cached(
     check_assumptions(rinex_3_obs_file, rinex_3_ephemerides_file)
     obs = helpers.parse_rinex_obs_file(rinex_3_obs_file)
 
-    obs_header = georinex.rinexheader(rinex_3_obs_file)
-    if "GLONASS SLOT / FRQ #" in obs_header.keys():
-        glonass_slot_dict = helpers.build_glonass_slot_dictionary(
-            obs_header["GLONASS SLOT / FRQ #"]
-        )
-    else:
-        glonass_slot_dict = None
-
     # Flatten the xarray DataSet into a pandas DataFrame:
     log.info("Converting Dataset into flat Dataframe of observations")
     flat_obs = pd.DataFrame()
@@ -325,11 +314,11 @@ def _build_records_cached(
         how="left",
     )
     # Compute anything else that is satellite-specific
-    sat_states[
-        "relativistic_clock_effect_m"
-    ] = helpers.compute_relativistic_clock_effect(
-        sat_states[["x_m", "y_m", "z_m"]].to_numpy(),
-        sat_states[["dx_mps", "dy_mps", "dz_mps"]].to_numpy(),
+    sat_states["relativistic_clock_effect_m"] = (
+        helpers.compute_relativistic_clock_effect(
+            sat_states[["x_m", "y_m", "z_m"]].to_numpy(),
+            sat_states[["dx_mps", "dy_mps", "dz_mps"]].to_numpy(),
+        )
     )
     sat_states["sagnac_effect_m"] = helpers.compute_sagnac_effect(
         sat_states[["x_m", "y_m", "z_m"]].to_numpy(),
@@ -390,13 +379,13 @@ def _build_records_cached(
         how="left",
     )
 
-    flat_obs.loc[
-        flat_obs.satellite.str[0] != "R", "carrier_frequency_hz"
-    ] = flat_obs.apply(
-        lambda row: constants.carrier_frequencies_hz()[row.satellite[0]][
-            "L" + row.observation_type[1]
-        ],
-        axis=1,
+    flat_obs.loc[flat_obs.satellite.str[0] != "R", "carrier_frequency_hz"] = (
+        flat_obs.apply(
+            lambda row: constants.carrier_frequencies_hz()[row.satellite[0]][
+                "L" + row.observation_type[1]
+            ],
+            axis=1,
+        )
     )
     nav_header = georinex.rinexheader(rinex_3_ephemerides_file)
     flat_obs.loc[

--- a/src/prx/main.py
+++ b/src/prx/main.py
@@ -213,7 +213,7 @@ def _build_records_cached(
             str(row[3]),
         ]
 
-    flat_obs = flat_obs.apply(          format_flat_rows, axis=1, result_type="expand")
+    flat_obs = flat_obs.apply(                  format_flat_rows, axis=1, result_type="expand")
     flat_obs = flat_obs.rename(
         columns={
             0: "time_of_reception_in_receiver_time",

--- a/src/prx/rinex_nav/find_datasets.py
+++ b/src/prx/rinex_nav/find_datasets.py
@@ -15,7 +15,7 @@ def main():
         password = "Quaxolotl1&"
         scraped_file = Path("./cddis_download") / (str(week) + ".html")
         os.makedirs(scraped_file.parent, exist_ok=True)
-        response = download_url(
+        download_url(
             url,
             username,
             password,

--- a/src/prx/rinex_nav/nav_file_discovery.py
+++ b/src/prx/rinex_nav/nav_file_discovery.py
@@ -104,9 +104,7 @@ def discover_or_download_auxiliary_files(observation_file_path=Path()):
         list(header["fields"].keys()),
     )
     if len(ephs) > 1:
-        assert (
-            False
-        ), "Observations crossing day boundaries not handled yet, need to merge ephemeris files here"
+        assert False, "Observations crossing day boundaries not handled yet, need to merge ephemeris files here"
     return {"broadcast_ephemerides": ephs[0]}
 
 

--- a/src/prx/rinex_nav/test/benchmark_evaluate.py
+++ b/src/prx/rinex_nav/test/benchmark_evaluate.py
@@ -39,7 +39,7 @@ def benchmark_1(query):
     rinex_nav_file = converters.compressed_to_uncompressed(
         Path(__file__).parent / "datasets/BRDC00IGS_R_20220010000_01D_MN.zip"
     )
-    rinex_sat_states = rinex_nav_evaluate.compute(rinex_nav_file, query)
+    rinex_nav_evaluate.compute(rinex_nav_file, query)
     pass
 
 

--- a/src/prx/rinex_nav/test/test_evaluate.py
+++ b/src/prx/rinex_nav/test/test_evaluate.py
@@ -4,7 +4,6 @@ from pathlib import Path
 from prx.sp3 import evaluate as sp3_evaluate
 from prx.rinex_nav import evaluate as rinex_nav_evaluate
 from prx import constants, converters, helpers
-from prx import constants
 from prx.helpers import timestamp_2_timedelta, week_and_seconds_2_timedelta
 import shutil
 import pytest

--- a/src/prx/rinex_nav/test/test_nav_file_discovery.py
+++ b/src/prx/rinex_nav/test/test_nav_file_discovery.py
@@ -38,13 +38,13 @@ def set_up_test():
 
 def test_find_local_ephemeris_file(set_up_test):
     aux_files = aux.discover_or_download_auxiliary_files(set_up_test["test_obs_file"])
-    assert type(aux_files) is dict
+    assert isinstance(aux_files, dict)
 
 
 def test_download_remote_ephemeris_files(set_up_test):
     os.remove(set_up_test["test_nav_file"])
     aux_files = aux.discover_or_download_auxiliary_files(set_up_test["test_obs_file"])
-    assert type(aux_files) is dict
+    assert isinstance(aux_files, dict)
 
 
 def test_command_line_call(set_up_test):

--- a/src/prx/sp3/evaluate.py
+++ b/src/prx/sp3/evaluate.py
@@ -96,8 +96,8 @@ def interpolate(df, query_time_gpst_s, plot_interpolation=False):
     assert (
         start_index >= 0
     ), f"We need at least {n_samples_each_side} before the sample closest to the query time to interpolate"
-    assert end_index < len(
-        df.index
+    assert (
+        end_index < len(df.index)
     ), f"We need at least {n_samples_each_side} after the sample closest to the query time to interpolate"
     columns_to_interpolate = ["x_m", "y_m", "z_m", "clock_m"]
     interpolated = df[closest_sample_index : closest_sample_index + 1]

--- a/src/prx/test/test_helpers.py
+++ b/src/prx/test/test_helpers.py
@@ -180,7 +180,7 @@ def test_satellite_elevation_and_azimuth():
 def test_sagnac_effect():
     # load validation data
     path_to_validation_file = (
-        helpers.prx_repository_root() / f"tools/validation_data/sagnac_effect.csv"
+        helpers.prx_repository_root() / "tools/validation_data/sagnac_effect.csv"
     )
 
     # satellite position (from reference CSV header)

--- a/src/prx/user.py
+++ b/src/prx/user.py
@@ -72,10 +72,13 @@ def spp_pt_lsq(df, dx_convergence_l2=1e-6, max_iterations=10):
     n_iterations = 0
     while solution_increment_l2 > dx_convergence_l2:
         # Compute predicted pseudo-range as geometric distance + receiver clock bias, predicted at x_linearization
-        C_obs_predicted = np.linalg.norm(
-            x_linearization[0:3].T - df[["x_m", "y_m", "z_m"]].to_numpy(), axis=1
-        ) + np.squeeze(  # geometric distance
-            H_clock @ x_linearization[3:]
+        C_obs_predicted = (
+            np.linalg.norm(
+                x_linearization[0:3].T - df[["x_m", "y_m", "z_m"]].to_numpy(), axis=1
+            )
+            + np.squeeze(  # geometric distance
+                H_clock @ x_linearization[3:]
+            )
         )  # rx to constellation clock bias
         # compute jacobian matrix
         rx_sat_vectors = df[["x_m", "y_m", "z_m"]].to_numpy() - x_linearization[:3].T


### PR DESCRIPTION
https://github.com/astral-sh/ruff is a faster alternative to black + flake8 + pylint.

With this PR, `ruff` is run  by the ubuntu CI step instead of flake8. The PR also fixes all `ruff check` complaints and re-formats with `ruff format`.

I installed the ruff plugin in pycharm and enabled File - Settings - Tools - Actions on Save - Reformat Code to ensure that code is automatically formatted.