### PR TITLE
Undefined GLONASS frequency slots

### DIFF
--- a/src/prx/main.py
+++ b/src/prx/main.py
@@ -431,12 +431,17 @@ def _build_records_cached(
         how="left",
     )
 
+    carrier_freqs = constants.carrier_frequencies_hz()
+
     def signal_2_carrier_frequency(row):
+        constellation = row.satellite[0]
+        frequency = "L" + row.observation_type[1]
+        frequency_slot = row["frequency_slot"]
         if np.isnan(row["frequency_slot"]):
             return np.nan
-        return constants.carrier_frequencies_hz()[row.satellite[0]][
-            "L" + row.observation_type[1]
-        ][row["frequency_slot"]]
+        if constellation not in carrier_freqs or frequency not in carrier_freqs[constellation] or frequency_slot not in carrier_freqs[constellation][frequency]:
+            return np.nan
+        return constants.carrier_frequencies_hz()[constellation][frequency][frequency_slot]
 
     flat_obs.loc[:, "carrier_frequency_hz"] = flat_obs.apply(
         signal_2_carrier_frequency, axis=1


### PR DESCRIPTION
When processing a longer observation file, I ran into GLONASS L3 observation with frequency slot -1. Since L3 is CDMA-only, the frequency slot should be 1. 