### PR TITLE
Parse Loss of Lock Indicator in RINEX OBS files

### DIFF
--- a/src/prx/main.py
+++ b/src/prx/main.py
@@ -106,7 +106,6 @@ def write_csv_file(
                 "tracking_id",
             ]
         ]
-        # obs[f"{obs_type}_obs_{type_2_unit[obs_type]}"] = obs.observation_value
         obs = obs.rename(
             columns={"observation_value": f"{obs_type}_obs_{type_2_unit[obs_type]}"}
         )
@@ -127,13 +126,6 @@ def write_csv_file(
                 how="left",
             )
             obs = obs.rename(columns={"observation_value": "LLI"})
-            obs["LLI"] = obs["LLI"].astype(int)
-
-        # obs = obs.drop(
-        #     columns=[
-        #         "observation_value",
-        #     ]
-        # )
         records = records.merge(
             obs,
             on=["satellite", "time_of_reception_in_receiver_time", "tracking_id"],

--- a/src/prx/rinex_obs/parser.py
+++ b/src/prx/rinex_obs/parser.py
@@ -102,9 +102,6 @@ def parse(file_path):
         group_df = pd.concat([group_df, group_lli], axis=1)
         group_df = group_df.stack().reset_index(drop=False)
         group_df.columns = ["time", "constellation", "sv", "obs_type", "obs_value"]
-        # drop rows with zero lli
-        zero_lli = group_df.obs_type.isin(types_lli) & (group_df.obs_value == 0)
-        group_df = group_df.loc[~zero_lli, :]
         group_df = group_df[["time", "sv", "obs_value", "obs_type"]]
         group_dfs.append(group_df)
     result = pd.concat(group_dfs).sort_values(by=["time"]).reset_index(drop=True)

--- a/src/prx/rinex_obs/parser.py
+++ b/src/prx/rinex_obs/parser.py
@@ -102,6 +102,9 @@ def parse(file_path):
         group_df = pd.concat([group_df, group_lli], axis=1)
         group_df = group_df.stack().reset_index(drop=False)
         group_df.columns = ["time", "constellation", "sv", "obs_type", "obs_value"]
+        # drop rows with zero lli
+        zero_lli = group_df.obs_type.isin(types_lli) & (group_df.obs_value == 0)
+        group_df = group_df.loc[~zero_lli, :]
         group_df = group_df[["time", "sv", "obs_value", "obs_type"]]
         group_dfs.append(group_df)
     result = pd.concat(group_dfs).sort_values(by=["time"]).reset_index(drop=True)

--- a/src/prx/rinex_obs/parser.py
+++ b/src/prx/rinex_obs/parser.py
@@ -73,15 +73,35 @@ def parse(file_path):
     obs["sv"] = df.sv
     obs["constellation"] = df.sv.str[0]
     obs["time"] = df.time
+
+    # retrieve loss of lock indicator
+    lli = (
+        df.records.str.split("|", expand=True)
+        .stack()
+        .str[block_length - 2 : block_length - 1]
+        .str.strip()
+        .replace({"": "0"})
+        .unstack()
+        .astype(int)
+    )
+    lli["constellation"] = df.sv.str[0]
+
     group_dfs = []
     for constellation, group_df in obs.groupby("constellation"):
         group_df.set_index(["time", "constellation", "sv"], inplace=True)
         types = obs_types[constellation]["obs_types"]
         group_df = group_df.iloc[:, : len(types)]
         group_df.columns = types
+        types_lli = [type + "lli" for type in types]
+        group_lli = lli.groupby("constellation").get_group(constellation)
+        group_lli = group_lli.iloc[:, : len(types)]
+        group_lli.columns = types_lli
+        group_lli.set_index(group_df.index, inplace=True)
+        columns_to_drop = [type for type in types_lli if type[0] != "L"]
+        group_lli = group_lli.drop(columns=columns_to_drop)
+        group_df = pd.concat([group_df, group_lli], axis=1)
         group_df = group_df.stack().reset_index(drop=False)
         group_df.columns = ["time", "constellation", "sv", "obs_type", "obs_value"]
-        group_df = group_df.drop(columns=["constellation"])
         group_df = group_df[["time", "sv", "obs_value", "obs_type"]]
         group_dfs.append(group_df)
     result = pd.concat(group_dfs).sort_values(by=["time"]).reset_index(drop=True)

--- a/src/prx/rinex_obs/test/benchmark.py
+++ b/src/prx/rinex_obs/test/benchmark.py
@@ -59,7 +59,6 @@ def generate_data():
     for case in cases:
         for parser in [
             ("prx", prx_obs_parse),
-            ("georinex", georinex.load),
         ]:
             print(f"Processing {case}")
             helpers.disk_cache.clear()

--- a/src/prx/rinex_obs/test/benchmark.py
+++ b/src/prx/rinex_obs/test/benchmark.py
@@ -25,8 +25,6 @@ def generate_data():
     )
     sweep_dir = base_file.parent / "sweep"
     results_file = sweep_dir / "benchmark.csv"
-    if results_file.exists():
-        return pd.read_csv(results_file)
     sweep_dir.mkdir(exist_ok=True)
     times = georinex.obstime3(base_file)
     header = georinex.rinexheader(base_file)
@@ -61,7 +59,7 @@ def generate_data():
     for case in cases:
         for parser in [
             ("prx", prx_obs_parse),
-            ("georinex", helpers.parse_rinex_obs_file),
+            ("georinex", georinex.load),
         ]:
             print(f"Processing {case}")
             helpers.disk_cache.clear()
@@ -78,6 +76,7 @@ def generate_data():
             )
     df = pd.DataFrame(cases)
     df.to_csv(results_file, index=False)
+    return df
 
 
 if __name__ == "__main__":

--- a/src/prx/rinex_obs/test/test_parser.py
+++ b/src/prx/rinex_obs/test/test_parser.py
@@ -91,7 +91,12 @@ def test_compare_to_georinex_with_lli(input_for_test_tlse):
         prx_lli = prx_output.loc[prx_output.obs_type == lli, :].reset_index(drop=True)
         assert geo_lli.equals(prx_lli)
 
+    # Negative assertion: I suspect a bug in georinex, that is not parsing all lli. If both prx and georinex parses
+    # the same lli, this assertion will fail and we may want to update this test to remove it.
     prx_lli_list = [type for type in prx_output.obs_type.unique() if "lli" in type]
+    assert (
+        set(geo_lli_list) != set(prx_lli_list)
+    ), "prx and georinex parse the same LLI! If georinex has been updated, you may want to remove this asssertion!!"
     for lli in prx_lli_list:
         if lli not in geo_lli_list:
             prx_lli = prx_output.loc[prx_output.obs_type == lli, :].reset_index(

--- a/src/prx/rinex_obs/test/test_parser.py
+++ b/src/prx/rinex_obs/test/test_parser.py
@@ -54,6 +54,56 @@ def test_compare_to_georinex():
     assert georinex_output.equals(prx_output)
 
 
+def test_compare_to_georinex_with_lli(input_for_test_tlse):
+    file = converters.anything_to_rinex_3(
+        Path(__file__).parent
+        / "datasets"
+        / "TLSE00FRA_R_20220010000_01D_30S_MO.rnx_slice_0.24h.rnx.gz"
+    )
+    repair_with_gfzrnx(file)
+    prx_output = (
+        prx_obs_parse(file)
+        .sort_values(by=["time", "sv", "obs_type"])
+        .reset_index(drop=True)
+    )
+
+    georinex_output = (
+        obs_dataset_to_obs_dataframe(georinex.load(file, useindicators=True))
+        .sort_values(by=["time", "sv", "obs_type"])
+        .reset_index(drop=True)
+    )
+
+    drop_ssi = [
+        obs_type for obs_type in georinex_output.obs_type.unique() if "ssi" in obs_type
+    ]
+    georinex_output = georinex_output.loc[~georinex_output.obs_type.isin(drop_ssi), :]
+
+    print("prx lli list:")
+    print([type for type in prx_output.obs_type.unique() if len(type) > 3])
+    print("georinex lli list:")
+    print([type for type in georinex_output.obs_type.unique() if len(type) > 3])
+
+    geo_lli_list = [type for type in georinex_output.obs_type.unique() if "lli" in type]
+    for lli in geo_lli_list:
+        geo_lli = georinex_output.loc[georinex_output.obs_type == lli, :].reset_index(
+            drop=True
+        )
+        prx_lli = prx_output.loc[prx_output.obs_type == lli, :].reset_index(drop=True)
+        assert geo_lli.equals(prx_lli)
+
+    prx_lli_list = [type for type in prx_output.obs_type.unique() if "lli" in type]
+    for lli in prx_lli_list:
+        if lli not in geo_lli_list:
+            prx_lli = prx_output.loc[prx_output.obs_type == lli, :].reset_index(
+                drop=True
+            )
+            geo_lli = georinex_output.loc[
+                georinex_output.obs_type == lli, :
+            ].reset_index(drop=True)
+            print(f"prx      has parsed {len(prx_lli)} CSs for obs {lli[0:3]}")
+            print(f"georinex has parsed {len(geo_lli)} CSs for obs {lli[0:3]}")
+
+
 def test_basic_check_on_rinex(input_for_test_tlse):
     prx_output = prx_obs_parse(input_for_test_tlse)
     test_cases = [

--- a/src/prx/rinex_obs/test/test_parser.py
+++ b/src/prx/rinex_obs/test/test_parser.py
@@ -38,11 +38,14 @@ def test_compare_to_georinex():
         / "TLSE00FRA_R_20220010000_01D_30S_MO.rnx_slice_0.24h.rnx.gz"
     )
     repair_with_gfzrnx(file)
-    prx_output = (
-        prx_obs_parse(file)
-        .sort_values(by=["time", "sv", "obs_type"])
-        .reset_index(drop=True)
-    )
+    prx_output = prx_obs_parse(file).sort_values(by=["time", "sv", "obs_type"])
+    # remove lli from prx outputs
+    drop_lli = [
+        obs_type for obs_type in prx_output.obs_type.unique() if "lli" in obs_type
+    ]
+    prx_output = prx_output.loc[~prx_output.obs_type.isin(drop_lli), :]
+    prx_output = prx_output.reset_index(drop=True)
+
     georinex_output = (
         obs_dataset_to_obs_dataframe(georinex.load(file))
         .sort_values(by=["time", "sv", "obs_type"])

--- a/src/prx/rinex_obs/test/test_parser.py
+++ b/src/prx/rinex_obs/test/test_parser.py
@@ -66,6 +66,12 @@ def test_compare_to_georinex_with_lli(input_for_test_tlse):
         .sort_values(by=["time", "sv", "obs_type"])
         .reset_index(drop=True)
     )
+    # remove zero lli rows
+    types_lli = set(
+        type_lli for type_lli in prx_output.obs_type.unique() if "lli" in type_lli
+    )
+    zero_lli = prx_output.obs_type.isin(types_lli) & (prx_output.obs_value == 0)
+    prx_output = prx_output.loc[~zero_lli, :]
 
     georinex_output = (
         obs_dataset_to_obs_dataframe(georinex.load(file, useindicators=True))
@@ -73,9 +79,13 @@ def test_compare_to_georinex_with_lli(input_for_test_tlse):
         .reset_index(drop=True)
     )
 
-    drop_ssi = [
-        obs_type for obs_type in georinex_output.obs_type.unique() if "ssi" in obs_type
-    ]
+    drop_ssi = set(
+        [
+            obs_type
+            for obs_type in georinex_output.obs_type.unique()
+            if "ssi" in obs_type
+        ]
+    )
     georinex_output = georinex_output.loc[~georinex_output.obs_type.isin(drop_ssi), :]
 
     print("prx lli list:")
@@ -83,7 +93,9 @@ def test_compare_to_georinex_with_lli(input_for_test_tlse):
     print("georinex lli list:")
     print([type for type in georinex_output.obs_type.unique() if len(type) > 3])
 
-    geo_lli_list = [type for type in georinex_output.obs_type.unique() if "lli" in type]
+    geo_lli_list = set(
+        [type for type in georinex_output.obs_type.unique() if "lli" in type]
+    )
     for lli in geo_lli_list:
         geo_lli = georinex_output.loc[georinex_output.obs_type == lli, :].reset_index(
             drop=True
@@ -93,9 +105,9 @@ def test_compare_to_georinex_with_lli(input_for_test_tlse):
 
     # Negative assertion: I suspect a bug in georinex, that is not parsing all lli. If both prx and georinex parses
     # the same lli, this assertion will fail and we may want to update this test to remove it.
-    prx_lli_list = [type for type in prx_output.obs_type.unique() if "lli" in type]
+    prx_lli_list = set([type for type in prx_output.obs_type.unique() if "lli" in type])
     assert (
-        set(geo_lli_list) != set(prx_lli_list)
+        geo_lli_list != prx_lli_list
     ), "prx and georinex parse the same LLI! If georinex has been updated, you may want to remove this asssertion!!"
     for lli in prx_lli_list:
         if lli not in geo_lli_list:

--- a/src/prx/test/test_main.py
+++ b/src/prx/test/test_main.py
@@ -152,6 +152,49 @@ def test_prx_function_call_with_csv_output(input_for_test_tlse):
     ).abs().max() < 0.3
 
 
+def test_prx_lli_parsing(input_for_test_tlse):
+    test_file = input_for_test_tlse
+    main.process(observation_file_path=test_file, output_format="csv")
+    expected_prx_file = Path(
+        str(test_file).replace("crx.gz", constants.cPrxCsvFileExtension)
+    )
+    df = pd.read_csv(expected_prx_file, comment="#")
+    # LLI check - CS expected (LLI = 1)
+    assert (
+        df.loc[
+            (df.time_of_reception_in_receiver_time == "2023-01-01 01:00:01.000000")
+            & (df.rnx_obs_identifier == "7D")
+            & (df.constellation == "C")
+            & (df.prn == 30),
+            "LLI",
+        ]
+        == 1
+    ).all()
+    assert (
+        df.loc[
+            (df.time_of_reception_in_receiver_time == "2023-01-01 01:00:07.000000")
+            & (df.rnx_obs_identifier.isin(["2W", "1C"]))
+            & (df.constellation == "G")
+            & (df.prn == 17),
+            "LLI",
+        ]
+        == 1
+    ).all()
+    # LLI check - no CS (LLI = 0)
+    assert (
+        df.loc[
+            (df.time_of_reception_in_receiver_time == "2023-01-01 01:00:07.000000")
+            & (df.rnx_obs_identifier == "2I")
+            & (df.constellation == "C")
+            & (df.prn == 5),
+            "LLI",
+        ]
+        == 0
+    ).all()
+    # LLI check - no phase tracking (L_obs_cycles = NaN and LLI = NaN)
+    assert df.loc[df.L_obs_cycles.isnull(), "LLI"].isnull().all()
+
+
 def test_prx_function_call_for_obs_file_across_two_days(
     input_for_test_with_first_epoch_at_midnight,
 ):


### PR DESCRIPTION
This PR adds the parsing of the Loss of Lock Indicator (LLI) from the RINEX OBS file.
It is added as a new column of the prx output.

Contrary to `georinex`, the `prx` parser keeps a LLI value to 0 when no CS is declared in the RINEX file.

By the way, I observed that `georinex` does not parse LLI for all available signals.