### PR TITLE
Output full nav file path

### DIFF
--- a/src/prx/rinex_nav/evaluate.py
+++ b/src/prx/rinex_nav/evaluate.py
@@ -24,6 +24,7 @@ def parse_rinex_nav_file(rinex_file: Path):
             rinex_file_path
         )
         df = convert_nav_dataset_to_dataframe(ds)
+        df["source"] = str(rinex_file_path.resolve())
         df["ephemeris_hash"] = pd.util.hash_pandas_object(df, index=False).astype(str)
         return df
 
@@ -416,7 +417,6 @@ def convert_nav_dataset_to_dataframe(nav_ds):
     # Drop ephemerides for which all parameters are NaN, as we cannot compute anything from those
     df = df.dropna(how="all")
     df = df.reset_index()
-    df["source"] = nav_ds.filename
     # georinex adds suffixes to satellite IDs if it sees multiple ephemerides (e.g. F/NAV, I/NAV) for the same
     # satellite and the same timestamp.
     # The downstream code expects three-letter satellite IDs, so remove suffixes.

--- a/src/prx/rinex_nav/test/test_evaluate.py
+++ b/src/prx/rinex_nav/test/test_evaluate.py
@@ -2,7 +2,11 @@ import numpy as np
 import pandas as pd
 from pathlib import Path
 
-from prx.rinex_nav.evaluate import select_ephemerides, set_time_of_validity
+from prx.rinex_nav.evaluate import (
+    select_ephemerides,
+    set_time_of_validity,
+    parse_rinex_nav_file,
+)
 from prx.sp3 import evaluate as sp3_evaluate
 from prx.rinex_nav import evaluate as rinex_nav_evaluate
 from prx import constants, converters, util
@@ -53,6 +57,16 @@ def input_for_test():
         assert test_file_path.exists()
     yield test_files
     shutil.rmtree(test_directory)
+
+
+def test_parse_nav_file(input_for_test):
+    path_to_rnx3_nav_file = converters.anything_to_rinex_3(
+        input_for_test["rinex_nav_file"]
+    )
+    df = parse_rinex_nav_file(path_to_rnx3_nav_file)
+    assert not df.empty
+    assert df["source"].nunique() == 1
+    assert df["source"].iloc[0] == str(path_to_rnx3_nav_file.resolve())
 
 
 def test_compare_rnx3_gps_sat_pos_with_magnitude(input_for_test):


### PR DESCRIPTION
Writes the full absolute path tho the source navigation file tot the output of the  nav file parser to make it easier to locate the file. Example use case: we see a weird field value in an ephemeris and want to check what the corresponding RINEX looks like - is it a formatting error or a genuine ephemeris value?