### PR TITLE
Fix in BDS GEO classification

### DIFF
--- a/src/prx/rinex_nav/evaluate.py
+++ b/src/prx/rinex_nav/evaluate.py
@@ -188,7 +188,7 @@ def is_bds_geo(constellation, inclination_rad, semi_major_axis_m):
         21528 * constants.cMetersPerKilometer + constants.cBdsCgcs2000SmiMajorAxis_m
     )
     radius_threshold_m = (
-        meo_approximate_radius_m - geo_and_igso_approximate_radius_m
+        meo_approximate_radius_m + geo_and_igso_approximate_radius_m
     ) / 2
     inclination_threshold_rad = inclination_igso_and_meo_rad / 2
     is_geo = (


### PR DESCRIPTION
Fixes MEO vs IGSO/GEO semi-major axis threshold computation. The bug had no impact because the function was also testing for inclination and hence correctly identified GEO satellites.

![Screenshot 2025-06-04 at 14 49 32](https://github.com/user-attachments/assets/b7222a42-0162-4ceb-b233-ce860e2a743a)
