### PR TITLE
Use polar's faster CSV parser

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,6 +31,8 @@ dependencies = [
     "requests<3.0.0,>=2.32.3",
     "hatchling>=1.27.0",
     "georinex",
+    "polars>=1.31.0",
+    "pyarrow>=20.0.0",
 ]
 
 [project.scripts]

--- a/src/prx/user.py
+++ b/src/prx/user.py
@@ -2,6 +2,7 @@ import json
 from pathlib import Path
 import numpy as np
 import pandas as pd
+import polars as pl
 import georinex as gr
 
 from prx.constants import cGpsSpeedOfLight_mps
@@ -17,7 +18,9 @@ def parse_prx_csv_file_metadata(prx_file: Path):
 
 
 def parse_prx_csv_file(prx_file: Path):
-    df = pd.read_csv(prx_file, comment="#")
+    df = pl.read_csv(
+        prx_file, comment_prefix="#", schema_overrides={"ephemeris_hash": pl.String}
+    ).to_pandas()
     df.time_of_reception_in_receiver_time = pd.to_datetime(
         df.time_of_reception_in_receiver_time
     )


### PR DESCRIPTION
With this PR, the `parse_prx_csv_file` fuction, a convenience function used by users and tests, runs polars' CSV parser, which seems to be a few times faster than pandas'.

On a 2.88 Gb file (24 hours of RINEX observations runn through prx) the timing is

```
0 days 00:00:02.916442 (polars)
0 days 00:00:18.665106 (pandas)
```