### PR TITLE
Adds format & lint make targets

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,8 +33,7 @@ jobs:
       - name: Run ruff
         if: ${{ matrix.os == 'ubuntu-latest' }}
         run: |
-          make type-check
-          make format-check
+          make format-lint-check
 
       - name: Test with pytest
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,8 +33,8 @@ jobs:
       - name: Run ruff
         if: ${{ matrix.os == 'ubuntu-latest' }}
         run: |
-          uv run ruff check --exit-non-zero-on-fix
-          uv run ruff format --check
+          make type-check
+          make format-check
 
       - name: Test with pytest
         run: |

--- a/Makefile
+++ b/Makefile
@@ -1,14 +1,10 @@
 test tests:
 	uv run pytest -n auto --dist=loadfile --durations=10
 
-format:
+format-lint:
 	uv run ruff format
-
-format-check:
-	uv run ruff format --check
-
-type-check-fix:
 	uv run ruff check --fix
 
-type-check:
+format-lint-check:
+	uv run ruff format --check
 	uv run ruff check

--- a/Makefile
+++ b/Makefile
@@ -1,2 +1,14 @@
 test tests:
 	uv run pytest -n auto --dist=loadfile --durations=10
+
+format:
+	uv run ruff format
+
+format-check:
+	uv run ruff format --check
+
+type-check-fix:
+	uv run ruff check --fix
+
+type-check:
+	uv run ruff check


### PR DESCRIPTION
Adds target to run format checks and linting through make without having to memorize or copy the ruff call.