### PR TITLE
Remove default argument function calls and build parent folder structure 

### DIFF
--- a/src/prx/precise_corrections/antex/antex_file_discovery.py
+++ b/src/prx/precise_corrections/antex/antex_file_discovery.py
@@ -58,11 +58,13 @@ def atx_file_database_folder():
     db_folder = (
         util.prx_repository_root() / "src/prx/precise_corrections/antex/atx_files"
     )
-    db_folder.mkdir(exist_ok=True)
+    db_folder.mkdir(exist_ok=True, parents=True)
     return db_folder
 
 
-def find_latest_local_antex_file(db_folder=atx_file_database_folder()) -> Path:
+def find_latest_local_antex_file(db_folder: Path | None = None) -> Path:
+    if db_folder is None:
+        db_folder = atx_file_database_folder()
     candidates = list(db_folder.glob(atx_filename))
     if not candidates:
         return None

--- a/src/prx/precise_corrections/sp3/sp3_file_discovery.py
+++ b/src/prx/precise_corrections/sp3/sp3_file_discovery.py
@@ -35,6 +35,8 @@ priority = [
     ("ESA", "RAP"),
     ("WUM", "RAP"),
 ]
+
+
 # WWWW/AAA0PPPTYP_YYYYDDDHHMM_LEN_SMP_CNT.FMT.gz
 # PPP : MGX
 # CNT : ORB
@@ -74,16 +76,16 @@ def sp3_file_database_folder() -> Path:
     Returns the path to the folder where SP3 database files are stored.
     """
     db_folder = util.prx_repository_root() / "src/prx/precise_corrections/sp3/sp3_files"
-    db_folder.mkdir(exist_ok=True)
+    db_folder.mkdir(exist_ok=True, parents=True)
     return db_folder
 
 
-def sp3_file_folder(
-    date: pd.Timestamp, parent_folder: Path = sp3_file_database_folder()
-) -> Path:
+def sp3_file_folder(date: pd.Timestamp, parent_folder: Path | None = None) -> Path:
     """
     Returns the path to the folder where SP3 files for a specific day are stored.
     """
+    if parent_folder is None:
+        parent_folder = sp3_file_database_folder()
     folder = parent_folder / f"{date.year}/{date.day_of_year:03d}"
     folder.mkdir(parents=True, exist_ok=True)
     return folder


### PR DESCRIPTION
Replaces 2 instances of

```
def function(argument: Type = another_function()):
  ...
```

by

```
def function(argument: Type|None = None):
  if argument is None:
    argument = another_function()
  ...
```

This makes sure that `another_function` is only called when `function` is called, and not when importing the module.

Also fixes parent's parent folders not being created automatically in two cases.