### PR TITLE
change root directory definition

### DIFF
--- a/src/prx/precise_corrections/antex/antex_file_discovery.py
+++ b/src/prx/precise_corrections/antex/antex_file_discovery.py
@@ -55,9 +55,7 @@ def atx_file_database_folder():
     """
     Returns the path to the folder where ATX database files are stored.
     """
-    db_folder = (
-        util.prx_repository_root() / "src/prx/precise_corrections/antex/atx_files"
-    )
+    db_folder = util.prx_repository_root() / "precise_corrections/antex/atx_files"
     db_folder.mkdir(exist_ok=True, parents=True)
     return db_folder
 

--- a/src/prx/precise_corrections/antex/antex_file_discovery.py
+++ b/src/prx/precise_corrections/antex/antex_file_discovery.py
@@ -55,7 +55,7 @@ def atx_file_database_folder():
     """
     Returns the path to the folder where ATX database files are stored.
     """
-    db_folder = util.prx_repository_root() / "precise_corrections/antex/atx_files"
+    db_folder = util.prx_src_directory() / "precise_corrections/antex/atx_files"
     db_folder.mkdir(exist_ok=True, parents=True)
     return db_folder
 

--- a/src/prx/precise_corrections/antex/test/test_antex_file_discovery.py
+++ b/src/prx/precise_corrections/antex/test/test_antex_file_discovery.py
@@ -22,8 +22,7 @@ def set_up_test(tmp_path_factory):
     test_obs_file = test_directory.joinpath("TLSE00FRA_R_20230010100_10S_01S_MO.crx.gz")
 
     shutil.copy(
-        util.prx_repository_root()
-        / f"src/prx/test/datasets/TLSE_2023001/{test_obs_file.name}",
+        util.prx_repository_root() / f"test/datasets/TLSE_2023001/{test_obs_file.name}",
         test_obs_file,
     )
     assert test_obs_file.exists()

--- a/src/prx/precise_corrections/antex/test/test_antex_file_discovery.py
+++ b/src/prx/precise_corrections/antex/test/test_antex_file_discovery.py
@@ -61,9 +61,11 @@ def test_download_if_not_local(set_up_test):
     db_folder = set_up_test["test_obs_file"].parent
 
     with (
-        patch(
+        patch(  # simulate fetching a up-to-date atx file
             "prx.precise_corrections.antex.antex_file_discovery.try_downloading_atx_ftp",
-            return_value=atx.fetch_latest_remote_antex_file(),
+            return_value=util.prx_src_directory().joinpath(
+                "prx", "precise_corrections", "antex", "atx_files", "igs20_3000.atx"
+            ),
         ),
         patch(  # simulate that the latest local file found is None
             "prx.precise_corrections.antex.antex_file_discovery.find_latest_local_antex_file",

--- a/src/prx/precise_corrections/antex/test/test_antex_file_discovery.py
+++ b/src/prx/precise_corrections/antex/test/test_antex_file_discovery.py
@@ -22,7 +22,7 @@ def set_up_test(tmp_path_factory):
     test_obs_file = test_directory.joinpath("TLSE00FRA_R_20230010100_10S_01S_MO.crx.gz")
 
     shutil.copy(
-        util.prx_repository_root() / f"test/datasets/TLSE_2023001/{test_obs_file.name}",
+        util.prx_src_directory() / f"test/datasets/TLSE_2023001/{test_obs_file.name}",
         test_obs_file,
     )
     assert test_obs_file.exists()

--- a/src/prx/precise_corrections/sp3/sp3_file_discovery.py
+++ b/src/prx/precise_corrections/sp3/sp3_file_discovery.py
@@ -75,7 +75,7 @@ def sp3_file_database_folder() -> Path:
     """
     Returns the path to the folder where SP3 database files are stored.
     """
-    db_folder = util.prx_repository_root() / "src/prx/precise_corrections/sp3/sp3_files"
+    db_folder = util.prx_repository_root() / "precise_corrections/sp3/sp3_files"
     db_folder.mkdir(exist_ok=True, parents=True)
     return db_folder
 

--- a/src/prx/precise_corrections/sp3/sp3_file_discovery.py
+++ b/src/prx/precise_corrections/sp3/sp3_file_discovery.py
@@ -75,7 +75,7 @@ def sp3_file_database_folder() -> Path:
     """
     Returns the path to the folder where SP3 database files are stored.
     """
-    db_folder = util.prx_repository_root() / "precise_corrections/sp3/sp3_files"
+    db_folder = util.prx_src_directory() / "precise_corrections/sp3/sp3_files"
     db_folder.mkdir(exist_ok=True, parents=True)
     return db_folder
 

--- a/src/prx/precise_corrections/sp3/test/test_sp3_file_discovey.py
+++ b/src/prx/precise_corrections/sp3/test/test_sp3_file_discovey.py
@@ -23,8 +23,7 @@ def set_up_test():
     test_obs_file = test_directory.joinpath("TLSE00FRA_R_20230010100_10S_01S_MO.crx.gz")
 
     shutil.copy(
-        util.prx_repository_root()
-        / f"src/prx/test/datasets/TLSE_2023001/{test_obs_file.name}",
+        util.prx_repository_root() / f"test/datasets/TLSE_2023001/{test_obs_file.name}",
         test_obs_file,
     )
     assert test_obs_file.exists()
@@ -34,8 +33,6 @@ def set_up_test():
     # copy all sp3 files
     for file in (
         util.prx_repository_root()
-        / "src"
-        / "prx"
         / "precise_corrections"
         / "sp3"
         / "test"
@@ -46,7 +43,7 @@ def set_up_test():
         test_sp3_file = sp3_subfolder / file.name
         shutil.copy(
             util.prx_repository_root()
-            / f"src/prx/precise_corrections/sp3/test/datasets/2023/001/{test_sp3_file.name}",
+            / f"precise_corrections/sp3/test/datasets/2023/001/{test_sp3_file.name}",
             test_sp3_file,
         )
         assert test_sp3_file.exists()

--- a/src/prx/precise_corrections/sp3/test/test_sp3_file_discovey.py
+++ b/src/prx/precise_corrections/sp3/test/test_sp3_file_discovey.py
@@ -23,7 +23,7 @@ def set_up_test():
     test_obs_file = test_directory.joinpath("TLSE00FRA_R_20230010100_10S_01S_MO.crx.gz")
 
     shutil.copy(
-        util.prx_repository_root() / f"test/datasets/TLSE_2023001/{test_obs_file.name}",
+        util.prx_src_directory() / f"test/datasets/TLSE_2023001/{test_obs_file.name}",
         test_obs_file,
     )
     assert test_obs_file.exists()
@@ -32,7 +32,7 @@ def set_up_test():
 
     # copy all sp3 files
     for file in (
-        util.prx_repository_root()
+        util.prx_src_directory()
         / "precise_corrections"
         / "sp3"
         / "test"
@@ -42,7 +42,7 @@ def set_up_test():
     ).glob("*"):
         test_sp3_file = sp3_subfolder / file.name
         shutil.copy(
-            util.prx_repository_root()
+            util.prx_src_directory()
             / f"precise_corrections/sp3/test/datasets/2023/001/{test_sp3_file.name}",
             test_sp3_file,
         )

--- a/src/prx/rinex_nav/test/test_nav_file_discovery.py
+++ b/src/prx/rinex_nav/test/test_nav_file_discovery.py
@@ -24,11 +24,11 @@ def set_up_test(tmp_path_factory):
     test_nav_file = test_directory.joinpath("BRDC00IGS_R_20230010000_01D_MN.rnx.gz")
 
     shutil.copy(
-        util.prx_repository_root() / f"test/datasets/TLSE_2023001/{test_obs_file.name}",
+        util.prx_src_directory() / f"test/datasets/TLSE_2023001/{test_obs_file.name}",
         test_obs_file,
     )
     shutil.copy(
-        util.prx_repository_root() / f"test/datasets/TLSE_2023001/{test_nav_file.name}",
+        util.prx_src_directory() / f"test/datasets/TLSE_2023001/{test_nav_file.name}",
         test_nav_file,
     )
 
@@ -72,9 +72,7 @@ def test_nav_file_http_availability_after_2022():
 
 def test_command_line_call(set_up_test):
     test_file = set_up_test["test_obs_file"]
-    aux_file_script_path = (
-        util.prx_repository_root() / "rinex_nav/nav_file_discovery.py"
-    )
+    aux_file_script_path = util.prx_src_directory() / "rinex_nav/nav_file_discovery.py"
 
     command = f"python {aux_file_script_path} --observation_file_path {test_file}"
     result = subprocess.run(

--- a/src/prx/rinex_nav/test/test_nav_file_discovery.py
+++ b/src/prx/rinex_nav/test/test_nav_file_discovery.py
@@ -24,13 +24,11 @@ def set_up_test(tmp_path_factory):
     test_nav_file = test_directory.joinpath("BRDC00IGS_R_20230010000_01D_MN.rnx.gz")
 
     shutil.copy(
-        util.prx_repository_root()
-        / f"src/prx/test/datasets/TLSE_2023001/{test_obs_file.name}",
+        util.prx_repository_root() / f"test/datasets/TLSE_2023001/{test_obs_file.name}",
         test_obs_file,
     )
     shutil.copy(
-        util.prx_repository_root()
-        / f"src/prx/test/datasets/TLSE_2023001/{test_nav_file.name}",
+        util.prx_repository_root() / f"test/datasets/TLSE_2023001/{test_nav_file.name}",
         test_nav_file,
     )
 
@@ -75,7 +73,7 @@ def test_nav_file_http_availability_after_2022():
 def test_command_line_call(set_up_test):
     test_file = set_up_test["test_obs_file"]
     aux_file_script_path = (
-        util.prx_repository_root() / "src/prx/rinex_nav/nav_file_discovery.py"
+        util.prx_repository_root() / "rinex_nav/nav_file_discovery.py"
     )
 
     command = f"python {aux_file_script_path} --observation_file_path {test_file}"

--- a/src/prx/test/test_atmospheric_corrections.py
+++ b/src/prx/test/test_atmospheric_corrections.py
@@ -21,7 +21,7 @@ def rnx3_input_for_test():
     rnx3_nav_test_file = test_directory.joinpath("BRDC00IGS_R_20220010000_01D_MN.zip")
     shutil.copy(
         util.prx_repository_root()
-        / f"src/prx/test/datasets/TLSE_2022001/{rnx3_nav_test_file.name}",
+        / f"test/datasets/TLSE_2022001/{rnx3_nav_test_file.name}",
         rnx3_nav_test_file,
     )
     assert rnx3_nav_test_file.exists()
@@ -278,7 +278,7 @@ def test_unb3m_corrections():
     tol = 1e-3
 
     tropo_expected = np.genfromtxt(
-        util.prx_repository_root() / "src/prx/tools/UNB3m_pack/tunb3m_.txt",
+        util.prx_repository_root() / "tools/UNB3m_pack/tunb3m_.txt",
         skip_header=3,
     )
 
@@ -303,7 +303,7 @@ def test_saastamoinen_corrections():
     # atmospheric_corrections.compute_tropo_delay_saastamoinen
 
     tropo_expected = np.genfromtxt(
-        util.prx_repository_root() / "src/prx/tools/UNB3m_pack/tunb3m_.txt",
+        util.prx_repository_root() / "tools/UNB3m_pack/tunb3m_.txt",
         skip_header=3,
     )
 

--- a/src/prx/test/test_atmospheric_corrections.py
+++ b/src/prx/test/test_atmospheric_corrections.py
@@ -20,7 +20,7 @@ def rnx3_input_for_test():
 
     rnx3_nav_test_file = test_directory.joinpath("BRDC00IGS_R_20220010000_01D_MN.zip")
     shutil.copy(
-        util.prx_repository_root()
+        util.prx_src_directory()
         / f"test/datasets/TLSE_2022001/{rnx3_nav_test_file.name}",
         rnx3_nav_test_file,
     )
@@ -278,7 +278,7 @@ def test_unb3m_corrections():
     tol = 1e-3
 
     tropo_expected = np.genfromtxt(
-        util.prx_repository_root() / "tools/UNB3m_pack/tunb3m_.txt",
+        util.prx_src_directory() / "tools/UNB3m_pack/tunb3m_.txt",
         skip_header=3,
     )
 
@@ -303,7 +303,7 @@ def test_saastamoinen_corrections():
     # atmospheric_corrections.compute_tropo_delay_saastamoinen
 
     tropo_expected = np.genfromtxt(
-        util.prx_repository_root() / "tools/UNB3m_pack/tunb3m_.txt",
+        util.prx_src_directory() / "tools/UNB3m_pack/tunb3m_.txt",
         skip_header=3,
     )
 

--- a/src/prx/test/test_converters.py
+++ b/src/prx/test/test_converters.py
@@ -22,7 +22,7 @@ def set_up_test(tmp_path_factory):
 def test_compressed_crx_to_rnx(set_up_test):
     compressed_compact_rinex_file = "TLSE00FRA_R_20230010100_10S_01S_MO.crx.gz"
     shutil.copy(
-        util.prx_repository_root()
+        util.prx_src_directory()
         / f"test/datasets/TLSE_2023001/{compressed_compact_rinex_file}",
         set_up_test["test_directory"].joinpath(compressed_compact_rinex_file),
     )
@@ -41,11 +41,11 @@ def test_converting_file_that_cannot_be_converted(set_up_test):
     # When trying to convert a file that cannot be converted into RINEX 3, expect the converter to return None
     does_not_contain_rinex_3 = "igs21906.sp3"
     assert (
-        util.prx_repository_root()
+        util.prx_src_directory()
         / f"test/datasets/TLSE_2022001/{does_not_contain_rinex_3}"
     ).exists()
     shutil.copy(
-        util.prx_repository_root()
+        util.prx_src_directory()
         / f"test/datasets/TLSE_2022001/{does_not_contain_rinex_3}",
         set_up_test["test_directory"].joinpath(does_not_contain_rinex_3),
     )

--- a/src/prx/test/test_converters.py
+++ b/src/prx/test/test_converters.py
@@ -23,7 +23,7 @@ def test_compressed_crx_to_rnx(set_up_test):
     compressed_compact_rinex_file = "TLSE00FRA_R_20230010100_10S_01S_MO.crx.gz"
     shutil.copy(
         util.prx_repository_root()
-        / f"src/prx/test/datasets/TLSE_2023001/{compressed_compact_rinex_file}",
+        / f"test/datasets/TLSE_2023001/{compressed_compact_rinex_file}",
         set_up_test["test_directory"].joinpath(compressed_compact_rinex_file),
     )
     rinex_3_file = converters.anything_to_rinex_3(
@@ -42,11 +42,11 @@ def test_converting_file_that_cannot_be_converted(set_up_test):
     does_not_contain_rinex_3 = "igs21906.sp3"
     assert (
         util.prx_repository_root()
-        / f"src/prx/test/datasets/TLSE_2022001/{does_not_contain_rinex_3}"
+        / f"test/datasets/TLSE_2022001/{does_not_contain_rinex_3}"
     ).exists()
     shutil.copy(
         util.prx_repository_root()
-        / f"src/prx/test/datasets/TLSE_2022001/{does_not_contain_rinex_3}",
+        / f"test/datasets/TLSE_2022001/{does_not_contain_rinex_3}",
         set_up_test["test_directory"].joinpath(does_not_contain_rinex_3),
     )
     assert (

--- a/src/prx/test/test_helpers.py
+++ b/src/prx/test/test_helpers.py
@@ -161,7 +161,7 @@ def test_satellite_elevation_and_azimuth():
 def test_sagnac_effect():
     # load validation data
     path_to_validation_file = (
-        util.prx_repository_root() / "tools/validation_data/sagnac_effect.csv"
+        util.prx_src_directory() / "tools/validation_data/sagnac_effect.csv"
     )
 
     # satellite position (from reference CSV header)

--- a/src/prx/test/test_helpers.py
+++ b/src/prx/test/test_helpers.py
@@ -161,7 +161,7 @@ def test_satellite_elevation_and_azimuth():
 def test_sagnac_effect():
     # load validation data
     path_to_validation_file = (
-        util.prx_repository_root() / "src/prx/tools/validation_data/sagnac_effect.csv"
+        util.prx_repository_root() / "tools/validation_data/sagnac_effect.csv"
     )
 
     # satellite position (from reference CSV header)

--- a/src/prx/test/test_main.py
+++ b/src/prx/test/test_main.py
@@ -166,7 +166,7 @@ def input_for_test_with_first_epoch_at_midnight(tmp_path_factory):
 
 def test_prx_command_line_call(input_for_test_tlse):
     test_file = input_for_test_tlse
-    prx_path = util.prx_repository_root() / "main.py"
+    prx_path = util.prx_src_directory() / "main.py"
     command = f"uv run python {prx_path} --observation_file_path {test_file}"
     result = subprocess.run(
         command, capture_output=True, shell=True, cwd=str(test_file.parent)

--- a/src/prx/test/test_main.py
+++ b/src/prx/test/test_main.py
@@ -166,7 +166,7 @@ def input_for_test_with_first_epoch_at_midnight(tmp_path_factory):
 
 def test_prx_command_line_call(input_for_test_tlse):
     test_file = input_for_test_tlse
-    prx_path = util.prx_repository_root() / "src/prx/main.py"
+    prx_path = util.prx_repository_root() / "main.py"
     command = f"uv run python {prx_path} --observation_file_path {test_file}"
     result = subprocess.run(
         command, capture_output=True, shell=True, cwd=str(test_file.parent)

--- a/src/prx/util.py
+++ b/src/prx/util.py
@@ -143,7 +143,7 @@ def configure_logging(log_level: str = "INFO"):
     terminal_handler = logging.StreamHandler()
     terminal_handler.setLevel(log_level.upper())
 
-    log_directory = prx_repository_root() / "logs"
+    log_directory = prx_src_directory() / "logs"
     log_directory.mkdir(exist_ok=True, parents=True)
     logfile_handler = logging.FileHandler(
         log_directory
@@ -159,7 +159,7 @@ def configure_logging(log_level: str = "INFO"):
         handler.setFormatter(formatter)
 
 
-def prx_repository_root() -> Path:
+def prx_src_directory() -> Path:
     return Path(__file__).parent
 
 

--- a/src/prx/util.py
+++ b/src/prx/util.py
@@ -160,7 +160,7 @@ def configure_logging(log_level: str = "INFO"):
 
 
 def prx_repository_root() -> Path:
-    return Path(__file__).parents[2]
+    return Path(__file__).parent
 
 
 def hash_of_file_content(file: Path, use_sampling: bool = False):


### PR DESCRIPTION
When installed as a package the original `util.prx_root_repository()` produced a folder outside of the package folder structure, creating problems.

I changed the root repository definition to `src/prx/`. The only impact is that the `logs` folder is created there.