### PR TITLE
Reduce peak RAM 

### DIFF
--- a/src/prx/converters.py
+++ b/src/prx/converters.py
@@ -51,6 +51,10 @@ def compact_rinex_obs_file_to_rinex_obs_file(file: Path):
     assert file.exists(), "File does not exist"
     if not is_compact_rinex_obs_file(file):
         return None
+    expanded_file = Path(str(file).replace(".crx", ".rnx"))
+    # CRX2RNX generates a slightly different uncompressed file when it already exists
+    if expanded_file.exists():
+        expanded_file.unlink()
     crx2rnx_binaries = glob.glob(
         str(Path(__file__).parent / "tools/RNXCMP/**/CRX2RNX*"), recursive=True
     )
@@ -59,7 +63,6 @@ def compact_rinex_obs_file_to_rinex_obs_file(file: Path):
         command = f" {crx2rnx_binary} -f {file}"
         result = subprocess.run(command, capture_output=True, shell=True)
         if result.returncode == 0:
-            expanded_file = Path(str(file).replace(".crx", ".rnx"))
             log.info(f"Converted compact Rinex to Rinex: {expanded_file}")
             return expanded_file
     return None

--- a/src/prx/rinex_nav/evaluate.py
+++ b/src/prx/rinex_nav/evaluate.py
@@ -340,14 +340,14 @@ def handle_bds_geos(eph):
             ]
         )
         rotation_matrices.append(np.matmul(Rz, Rx))
-    R = scipy.linalg.block_diag(*rotation_matrices)
-    P_K = np.matmul(R, P_GK)
+    R = scipy.sparse.block_diag(rotation_matrices)
+    P_K = R @ P_GK
     P_K = np.reshape(P_K, (-1, 3))
     geos["X_k"] = P_K[:, 0]
     geos["Y_k"] = P_K[:, 1]
     geos["Z_k"] = P_K[:, 2]
     # Velocity in inertial frame that coincides with BDCS at this time, ie a "frozen" ECEF frame
-    V_K_frozen = np.matmul(R, V_GK)
+    V_K_frozen = R @ V_GK
     V_K_frozen = np.reshape(V_K_frozen, (-1, 3))
     geos["dX_k"] = V_K_frozen[:, 0]
     geos["dY_k"] = V_K_frozen[:, 1]


### PR DESCRIPTION
Reduces peak RAM usage by about 90%  by exploiting sparsity of the huge block-diagonal matrix used to compute BDS GEO orbital positions and velocities. 


# Before

<img width="1884" height="909" alt="Screenshot 2026-05-22 at 22 20 38" src="https://github.com/user-attachments/assets/54aa36a3-77f9-4fde-8304-a2b6969e6740" />


# After

<img width="1654" height="920" alt="Screenshot 2026-05-22 at 23 56 53" src="https://github.com/user-attachments/assets/893de1a4-0ffa-4833-87ab-2e2d5a43f7f8" />
