### PR TITLE
More polars

### DIFF
--- a/src/prx/atmospheric_corrections.py
+++ b/src/prx/atmospheric_corrections.py
@@ -148,7 +148,9 @@ def add_iono_column(
         else:
             logging.warning(f"Missing iono model parameters for day {doy:03d}")
             iono_all_days.append(np.full(mask_idx.shape, np.nan))
-    return np.concatenate(idx_all_days), np.concatenate(iono_all_days)
+    delays = np.ones((len(flat_obs.index))) * np.nan
+    delays[np.concatenate(idx_all_days)] = np.concatenate(iono_all_days)
+    return delays
 
 
 def compute_tropo_delay_saastamoinen(height, el, lat, humi=0.7):

--- a/src/prx/atmospheric_corrections.py
+++ b/src/prx/atmospheric_corrections.py
@@ -2,6 +2,9 @@ import numpy as np
 import pandas as pd
 import georinex
 import logging
+
+from numpy.typing import NDArray
+
 from prx.util import deg_2_rad, ecef_2_geodetic, timedelta_2_weeks_and_seconds
 import prx.constants as constants
 
@@ -420,7 +423,12 @@ def compute_tropo_delay_unb3m(
     )
 
 
-def compute_tropo_delay(sat_states, flat_obs, receiver_ecef_position_m, model):
+def compute_tropo_delay(
+    elevation_rad: NDArray,
+    time_isagpst: NDArray,
+    receiver_ecef_position_m: NDArray,
+    model: str,
+):
     """
     model is either "saastamoinen" or "unb3m"
     """
@@ -428,28 +436,12 @@ def compute_tropo_delay(sat_states, flat_obs, receiver_ecef_position_m, model):
     match model:
         case "saastamoinen":
             tropo_delay_m, _, _ = compute_tropo_delay_saastamoinen(
-                height_user_m * np.ones((len(sat_states),)),
-                sat_states.elevation_rad.to_numpy(),
-                latitude_user_rad * np.ones((len(sat_states),)),
+                height_user_m * np.ones((len(elevation_rad),)),
+                elevation_rad,
+                latitude_user_rad * np.ones((len(elevation_rad),)),
             )
         case "unb3m":
-            # We need Timestamps to compute tropo delays
-            sat_states = sat_states.merge(
-                flat_obs[
-                    [
-                        "satellite",
-                        "time_of_emission_isagpst",
-                        "time_of_reception_in_receiver_time",
-                    ]
-                ].drop_duplicates(),
-                on=["satellite", "time_of_emission_isagpst"],
-                how="left",
-            )
-            days_of_year = np.array(
-                sat_states["time_of_reception_in_receiver_time"]
-                .apply(lambda element: element.timetuple().tm_yday)
-                .to_numpy()
-            )
+            days_of_year = pd.Series(time_isagpst).dt.dayofyear.to_numpy()
             (
                 tropo_delay_m,
                 __,
@@ -457,11 +449,11 @@ def compute_tropo_delay(sat_states, flat_obs, receiver_ecef_position_m, model):
                 __,
                 __,
             ) = compute_tropo_delay_unb3m(
-                latitude_user_rad * np.ones((len(sat_states),)),
-                height_user_m * np.ones((len(sat_states),)),
+                latitude_user_rad * np.ones((len(elevation_rad),)),
+                height_user_m * np.ones((len(elevation_rad),)),
                 days_of_year,
-                sat_states.elevation_rad.to_numpy(),
+                elevation_rad,
             )
         case _:
-            assert False, f"tropospheric model not recognized: {model}"
+            raise AssertionError(f"tropospheric model not recognized: {model}")
     return tropo_delay_m

--- a/src/prx/constants.py
+++ b/src/prx/constants.py
@@ -20,7 +20,7 @@ cHzPerMhz = 1e6
 cWgs84EarthFlatteningFactor = 1 / 298.257223563
 cWgs84EarthSemiMajorAxis_m = 6378137.0
 cWgs84EarthEccentricity = np.sqrt(
-    2 * cWgs84EarthFlatteningFactor - cWgs84EarthFlatteningFactor**2
+    2 * cWgs84EarthFlatteningFactor - cWgs84EarthFlatteningFactor ** 2
 )
 # GPS ICD constants
 cGpsPi = 3.1415926535898
@@ -129,5 +129,5 @@ system_time_scale_rinex_utc_epoch = {
     "GST": cGpstUtcEpoch,
     "BDT": cBdtUtcEpoch,
     # GLONASS time does not use weeks and week seconds, it has no epoch,
-    "GLONASST": pd.NaT,
+    "GLONASST": None,
 }

--- a/src/prx/constants.py
+++ b/src/prx/constants.py
@@ -20,7 +20,7 @@ cHzPerMhz = 1e6
 cWgs84EarthFlatteningFactor = 1 / 298.257223563
 cWgs84EarthSemiMajorAxis_m = 6378137.0
 cWgs84EarthEccentricity = np.sqrt(
-    2 * cWgs84EarthFlatteningFactor - cWgs84EarthFlatteningFactor ** 2
+    2 * cWgs84EarthFlatteningFactor - cWgs84EarthFlatteningFactor**2
 )
 # GPS ICD constants
 cGpsPi = 3.1415926535898

--- a/src/prx/main.py
+++ b/src/prx/main.py
@@ -203,9 +203,18 @@ def assign_carrier_frequencies(flat_obs):
         orient="records"
     )[0]
     freq_dict[None] = None
-    keys = flat_obs["satellite"].str.slice(0,1) + "_L" + flat_obs["observation_type"].str.slice(1,1) + "_" + flat_obs["frequency_slot"].cast(int).cast(str)
-    flat_obs = flat_obs.with_columns(keys.replace(freq_dict).cast(float).alias("carrier_frequency_hz"))
+    keys = (
+        flat_obs["satellite"].str.slice(0, 1)
+        + "_L"
+        + flat_obs["observation_type"].str.slice(1, 1)
+        + "_"
+        + flat_obs["frequency_slot"].cast(int).cast(str)
+    )
+    flat_obs = flat_obs.with_columns(
+        keys.replace(freq_dict).cast(float).alias("carrier_frequency_hz")
+    )
     return flat_obs
+
 
 @util.timeit
 def build_records_levels_12(
@@ -214,7 +223,7 @@ def build_records_levels_12(
     approximate_receiver_ecef_position_m,
     prx_level,
     model_tropo,
-    joblib_backend: str = "threading",
+    joblib_backend: str = "loky",
 ):
     """
     Creates a flat_obs dataframe including columns for prx processing levels 1 and 2.
@@ -404,21 +413,21 @@ def build_records_levels_12(
     flat_obs = flat_obs.with_columns(
         pl.when(
             pl.col("satellite").str.starts_with("R")
-            & (pl.col("observation_type").str.slice(1,1).cast(int) > 2)
+            & (pl.col("observation_type").str.slice(1, 1).cast(int) > 2)
         )
         .then(1)
         .otherwise(pl.col("frequency_slot"))
         .alias("frequency_slot")
     )
 
-
-
     flat_obs = assign_carrier_frequencies(flat_obs).drop(["frequency_slot"])
 
     if prx_level == 2:
         # add iono correction
         iono_delay = atmo.add_iono_column(
-            flat_obs.to_pandas(), rinex_3_ephemerides_files, approximate_receiver_ecef_position_m
+            flat_obs.to_pandas(),
+            rinex_3_ephemerides_files,
+            approximate_receiver_ecef_position_m,
         )
         flat_obs = flat_obs.with_columns(iono_delay_m=iono_delay)
 
@@ -574,7 +583,10 @@ def build_records_level_3(
 
     # TODO: change to TROPEX when implemented
     sat_states["tropo_delay_m"] = atmo.compute_tropo_delay(
-        sat_states, flat_obs, approximate_receiver_ecef_position_m, model_tropo
+        sat_states["elevation_rad"].to_numpy(),
+        sat_states["time_of_emission_isagpst"].to_numpy(),
+        approximate_receiver_ecef_position_m,
+        model_tropo,
     )
 
     # Merge sat states into observation dataframe. Due to Galileo's FNAV/INAV ephemerides
@@ -627,10 +639,10 @@ def build_records_level_3(
     rnx3_nav_files = nav_file_discovery.discover_or_download_auxiliary_files(
         rinex_3_obs_file
     )["broadcast_ephemerides"]
-    iono_idx, iono_delay = atmo.add_iono_column(
+    iono_delay = atmo.add_iono_column(
         flat_obs, rnx3_nav_files, approximate_receiver_ecef_position_m
     )
-    flat_obs.loc[iono_idx, "iono_delay_m"] = iono_delay
+    flat_obs["iono_delay_m"] = iono_delay
 
     return flat_obs
 

--- a/src/prx/main.py
+++ b/src/prx/main.py
@@ -277,7 +277,7 @@ def build_records_levels_12(
     # satellite clock offset plus those small terms of a few tens of nanoseconds
     per_sat = per_sat.with_columns(
         (
-            1e3
+            1e9
             * (pl.mean_horizontal(code_phase_columns) / constants.cGpsSpeedOfLight_mps)
         )
         .cast(pl.Duration(time_unit="ns"))

--- a/src/prx/main.py
+++ b/src/prx/main.py
@@ -26,9 +26,9 @@ log = logging.getLogger(__name__)
 
 @util.timeit
 def write_prx_file(
-    prx_header: dict,
-    prx_records_pd: pd.DataFrame,
-    file_name_without_extension: Path,
+        prx_header: dict,
+        prx_records_pd: pd.DataFrame,
+        file_name_without_extension: Path,
 ):
     output_file = Path(f"{str(file_name_without_extension)}.csv")
     prx_records = pl.from_pandas(prx_records_pd)
@@ -162,9 +162,9 @@ def build_metadata(input_files):
     ]
     try:
         prx_metadata["prx_git_commit_id"] = (
-            util.git_sha_of_this_package()
-            or util.git_sha_from_dist_info("prx")
-            or "unknown"
+                util.git_sha_of_this_package()
+                or util.git_sha_from_dist_info("prx")
+                or "unknown"
         )
     except git.exc.InvalidGitRepositoryError:
         prx_metadata["prx_git_commit_id"] = "not_a_git_repository"
@@ -172,7 +172,7 @@ def build_metadata(input_files):
 
 
 def check_assumptions(
-    rinex_3_obs_file,
+        rinex_3_obs_file,
 ):
     obs_header = georinex.rinexheader(rinex_3_obs_file)
     if "RCV CLOCK OFFS APPL" in obs_header.keys():
@@ -200,12 +200,12 @@ def warm_up_parser_cache(rinex_files):
 
 @util.timeit
 def build_records_levels_12(
-    rinex_3_obs_file,
-    rinex_3_ephemerides_files,
-    approximate_receiver_ecef_position_m,
-    prx_level,
-    model_tropo,
-    joblib_backend: str = "loky",
+        rinex_3_obs_file,
+        rinex_3_ephemerides_files,
+        approximate_receiver_ecef_position_m,
+        prx_level,
+        model_tropo,
+        joblib_backend: str = "threading",
 ):
     """
     Creates a flat_obs dataframe including columns for prx processing levels 1 and 2.
@@ -217,14 +217,10 @@ def build_records_levels_12(
         approximate_receiver_ecef_position_m
     )
     check_assumptions(rinex_3_obs_file)
-    flat_obs = parse_rinex_obs_file(rinex_3_obs_file)
-
-    flat_obs.time = pd.to_datetime(flat_obs.time, format="%Y-%m-%dT%H:%M:%S")
-    flat_obs.obs_value = flat_obs.obs_value.astype(float)
-    flat_obs[["sv", "obs_type"]] = flat_obs[["sv", "obs_type"]].astype(str)
+    flat_obs = pl.from_pandas(parse_rinex_obs_file(rinex_3_obs_file))
 
     flat_obs = flat_obs.rename(
-        columns={
+        {
             "time": "time_of_reception_in_receiver_time",
             "sv": "satellite",
             "obs_value": "observation_value",
@@ -237,13 +233,23 @@ def build_records_levels_12(
         index=["time_of_reception_in_receiver_time", "satellite"],
         columns=["observation_type"],
         values="observation_value",
-    ).reset_index()
-    per_sat["time_scale"] = (
-        per_sat["satellite"].str[0].map(constants.constellation_2_system_time_scale)
     )
-    per_sat["system_time_scale_epoch"] = per_sat["time_scale"].map(
-        constants.system_time_scale_rinex_utc_epoch
+    per_sat = per_sat.with_columns(
+        pl.col("satellite")
+        .str.slice(0, 1)
+        .replace(constants.constellation_2_system_time_scale)
+        .alias("time_scale"),
     )
+    per_sat = per_sat.with_columns(
+        pl.col("time_scale")
+        .replace_strict(
+            constants.system_time_scale_rinex_utc_epoch,
+            default=None,
+            return_dtype=pl.Datetime("ns"),
+        )
+        .alias("system_time_scale_epoch"),
+    )
+
     # When calling georinex.load() with useindicators=True, there are additional ssi columns such as C1Cssi.
     # To exclude them, we check the length of the column name
     code_phase_columns = [c for c in per_sat.columns if c[0] == "C" and len(c) == 3]
@@ -260,17 +266,14 @@ def build_records_levels_12(
     # By subtracting the term from the receiver time of reception, we get the time of emission in
     # the satellite's constellation time frame (integer-second aligned to the receiver time frame), plus the
     # satellite clock offset plus those small terms of a few tens of nanoseconds
-    tof_dtrx = pd.to_timedelta(
-        per_sat[code_phase_columns]
-        .mean(axis=1, skipna=True)
-        .divide(constants.cGpsSpeedOfLight_mps),
-        unit="s",
+    per_sat = per_sat.with_columns(
+        (pl.mean_horizontal(code_phase_columns) / constants.cGpsSpeedOfLight_mps).cast(
+            pl.Duration(time_unit="ms")).alias("tof_dtrx")
     )
     # As error terms are tens of nanoseconds here, and the receiver clock is integer-second aligned to GPST, we
     # already have times-of-emission that are integer-second aligned GPST here.
-    per_sat["time_of_emission_isagpst"] = (
-        per_sat["time_of_reception_in_receiver_time"] - tof_dtrx
-    )
+    per_sat = per_sat.with_columns(
+        (pl.col("time_of_reception_in_receiver_time") - pl.col("tof_dtrx")).alias("time_of_reception_in_receiver_time"))
 
     flat_obs = flat_obs.merge(
         per_sat[
@@ -301,14 +304,14 @@ def build_records_levels_12(
         doy = int(file.name[16:19])
         day_query = query.loc[
             (
-                query.query_time_isagpst
-                >= pd.Timestamp(year=year, month=1, day=1) + pd.Timedelta(days=doy - 1)
+                    query.query_time_isagpst
+                    >= pd.Timestamp(year=year, month=1, day=1) + pd.Timedelta(days=doy - 1)
             )
             & (
-                query.query_time_isagpst
-                < pd.Timestamp(year=year, month=1, day=1) + pd.Timedelta(days=doy)
+                    query.query_time_isagpst
+                    < pd.Timestamp(year=year, month=1, day=1) + pd.Timedelta(days=doy)
             )
-        ]
+            ]
         if day_query.empty:
             continue
 
@@ -371,7 +374,7 @@ def build_records_levels_12(
     glo_cdma = flat_obs[
         (flat_obs.satellite.str[0] == "R")
         & (flat_obs["observation_type"].str[1].astype(int) > 2)
-    ]
+        ]
     flat_obs.loc[glo_cdma.index, "frequency_slot"] = int(1)
 
     def assign_carrier_frequencies(flat_obs):
@@ -380,11 +383,11 @@ def build_records_levels_12(
         )[0]
         assignable = flat_obs.frequency_slot.notna()
         keys = (
-            flat_obs.satellite[assignable].str[0]
-            + "_L"
-            + flat_obs["observation_type"][assignable].str[1]
-            + "_"
-            + flat_obs.frequency_slot[assignable].astype(int).astype(str)
+                flat_obs.satellite[assignable].str[0]
+                + "_L"
+                + flat_obs["observation_type"][assignable].str[1]
+                + "_"
+                + flat_obs.frequency_slot[assignable].astype(int).astype(str)
         )
         flat_obs.loc[:, "carrier_frequency_hz"] = keys.map(freq_dict)
         return flat_obs
@@ -402,11 +405,11 @@ def build_records_levels_12(
 
 
 def build_records_level_3(
-    rinex_3_obs_file,
-    sp3_orbit_files,
-    atx_file,
-    approximate_receiver_ecef_position_m,
-    model_tropo,
+        rinex_3_obs_file,
+        sp3_orbit_files,
+        atx_file,
+        approximate_receiver_ecef_position_m,
+        model_tropo,
 ):
     """
     Creates a flat_obs dataframe including columns for prx processing level 3.
@@ -468,7 +471,7 @@ def build_records_level_3(
     # As error terms are tens of nanoseconds here, and the receiver clock is integer-second aligned to GPST, we
     # already have times-of-emission that are integer-second aligned GPST here.
     per_sat["time_of_emission_isagpst"] = (
-        per_sat["time_of_reception_in_receiver_time"] - tof_dtrx
+            per_sat["time_of_reception_in_receiver_time"] - tof_dtrx
     )
 
     flat_obs = flat_obs.merge(
@@ -503,14 +506,14 @@ def build_records_level_3(
         doy = int(file.name[15:18])
         day_query = query.loc[
             (
-                query.query_time_isagpst
-                >= pd.Timestamp(year=year, month=1, day=1) + pd.Timedelta(days=doy - 1)
+                    query.query_time_isagpst
+                    >= pd.Timestamp(year=year, month=1, day=1) + pd.Timedelta(days=doy - 1)
             )
             & (
-                query.query_time_isagpst
-                < pd.Timestamp(year=year, month=1, day=1) + pd.Timedelta(days=doy)
+                    query.query_time_isagpst
+                    < pd.Timestamp(year=year, month=1, day=1) + pd.Timedelta(days=doy)
             )
-        ]
+            ]
         if day_query.empty:
             continue
 
@@ -576,7 +579,7 @@ def build_records_level_3(
     glo_cdma = flat_obs[
         (flat_obs.satellite.str[0] == "R")
         & (flat_obs["observation_type"].str[1].astype(int) > 2)
-    ]
+        ]
     flat_obs.loc[glo_cdma.index, "frequency_slot"] = int(1)
 
     # set frequency slot to 1 for non-GLONASS satellites
@@ -588,11 +591,11 @@ def build_records_level_3(
         )[0]
         assignable = flat_obs.frequency_slot.notna()
         keys = (
-            flat_obs.satellite[assignable].str[0]
-            + "_L"
-            + flat_obs["observation_type"][assignable].str[1]
-            + "_"
-            + flat_obs.frequency_slot[assignable].astype(int).astype(str)
+                flat_obs.satellite[assignable].str[0]
+                + "_L"
+                + flat_obs["observation_type"][assignable].str[1]
+                + "_"
+                + flat_obs.frequency_slot[assignable].astype(int).astype(str)
         )
         flat_obs.loc[:, "carrier_frequency_hz"] = keys.map(freq_dict)
         return flat_obs
@@ -613,10 +616,10 @@ def build_records_level_3(
 
 @util.timeit
 def process(
-    observation_file_path: Path,
-    prx_level=2,
-    model_tropo="saastamoinen",
-    joblib_backend: str = "loky",
+        observation_file_path: Path,
+        prx_level=2,
+        model_tropo="saastamoinen",
+        joblib_backend: str = "loky",
 ):
     t0 = pd.Timestamp.now()
     # We expect a Path, but might get a string here:
@@ -685,7 +688,7 @@ if __name__ == "__main__":
     parser = argparse.ArgumentParser(
         prog="prx",
         description="prx processes RINEX observations, computes a few useful things such as satellite position, "
-        "relativistic effects etc. and outputs everything to a text file in a convenient format.",
+                    "relativistic effects etc. and outputs everything to a text file in a convenient format.",
         epilog="P.S. GNSS rules!",
     )
     parser.add_argument(

--- a/src/prx/main.py
+++ b/src/prx/main.py
@@ -198,6 +198,15 @@ def warm_up_parser_cache(rinex_files):
     _ = [parse_rinex_nav_or_obs_file(file) for file in rinex_files]
 
 
+def assign_carrier_frequencies(flat_obs):
+    freq_dict = pd.json_normalize(carrier_frequencies_hz(), sep="_").to_dict(
+        orient="records"
+    )[0]
+    freq_dict[None] = None
+    keys = flat_obs["satellite"].str.slice(0,1) + "_L" + flat_obs["observation_type"].str.slice(1,1) + "_" + flat_obs["frequency_slot"].cast(int).cast(str)
+    flat_obs = flat_obs.with_columns(keys.replace(freq_dict).cast(float).alias("carrier_frequency_hz"))
+    return flat_obs
+
 @util.timeit
 def build_records_levels_12(
     rinex_3_obs_file,
@@ -271,7 +280,7 @@ def build_records_levels_12(
             1e3
             * (pl.mean_horizontal(code_phase_columns) / constants.cGpsSpeedOfLight_mps)
         )
-        .cast(pl.Duration(time_unit="ms"))
+        .cast(pl.Duration(time_unit="ns"))
         .alias("tof_dtrx")
     )
     # As error terms are tens of nanoseconds here, and the receiver clock is integer-second aligned to GPST, we
@@ -375,51 +384,45 @@ def build_records_levels_12(
     )
     flat_obs = flat_obs.with_columns(code_id=pl.col("observation_type").str.slice(1, 2))
 
-    flat_obs = flat_obs.merge(
-        sat_states.drop(columns=["observation_type"]),
+    flat_obs = flat_obs.join(
+        sat_states.drop(["observation_type"]),
         on=["satellite", "code_id", "time_of_emission_isagpst"],
         how="left",
-    ).drop(columns=["code_id"])
+    ).drop(["code_id"])
 
     if prx_level == 2:
         # Fix code biases being merged into lines with signals that are not code signals
-        flat_obs.loc[
-            ~(flat_obs.observation_type.str.startswith("C")), "sat_code_bias_m"
-        ] = np.nan
+        flat_obs = flat_obs.with_columns(
+            pl.when(pl.col("observation_type").str.starts_with("C").not_())
+            .then(np.nan)
+            .otherwise(pl.col("sat_code_bias_m"))
+            .alias("sat_code_bias_m")
+        )
 
     # GLONASS satellites with both FDMA and CDMA signals have a frequency slot for FDMA signals,
     # for CDMA signals we use the common carrier frequency of those signals.
-    glo_cdma = flat_obs[
-        (flat_obs.satellite.str[0] == "R")
-        & (flat_obs["observation_type"].str[1].astype(int) > 2)
-    ]
-    flat_obs.loc[glo_cdma.index, "frequency_slot"] = int(1)
-
-    def assign_carrier_frequencies(flat_obs):
-        freq_dict = pd.json_normalize(carrier_frequencies_hz(), sep="_").to_dict(
-            orient="records"
-        )[0]
-        assignable = flat_obs.frequency_slot.notna()
-        keys = (
-            flat_obs.satellite[assignable].str[0]
-            + "_L"
-            + flat_obs["observation_type"][assignable].str[1]
-            + "_"
-            + flat_obs.frequency_slot[assignable].astype(int).astype(str)
+    flat_obs = flat_obs.with_columns(
+        pl.when(
+            pl.col("satellite").str.starts_with("R")
+            & (pl.col("observation_type").str.slice(1,1).cast(int) > 2)
         )
-        flat_obs.loc[:, "carrier_frequency_hz"] = keys.map(freq_dict)
-        return flat_obs
+        .then(1)
+        .otherwise(pl.col("frequency_slot"))
+        .alias("frequency_slot")
+    )
 
-    flat_obs = assign_carrier_frequencies(flat_obs).drop(columns=["frequency_slot"])
+
+
+    flat_obs = assign_carrier_frequencies(flat_obs).drop(["frequency_slot"])
 
     if prx_level == 2:
         # add iono correction
-        iono_idx, iono_delay = atmo.add_iono_column(
-            flat_obs, rinex_3_ephemerides_files, approximate_receiver_ecef_position_m
+        iono_delay = atmo.add_iono_column(
+            flat_obs.to_pandas(), rinex_3_ephemerides_files, approximate_receiver_ecef_position_m
         )
-        flat_obs.loc[iono_idx, "iono_delay_m"] = iono_delay
+        flat_obs = flat_obs.with_columns(iono_delay_m=iono_delay)
 
-    return flat_obs
+    return flat_obs.to_pandas()
 
 
 def build_records_level_3(

--- a/src/prx/main.py
+++ b/src/prx/main.py
@@ -26,9 +26,9 @@ log = logging.getLogger(__name__)
 
 @util.timeit
 def write_prx_file(
-        prx_header: dict,
-        prx_records_pd: pd.DataFrame,
-        file_name_without_extension: Path,
+    prx_header: dict,
+    prx_records_pd: pd.DataFrame,
+    file_name_without_extension: Path,
 ):
     output_file = Path(f"{str(file_name_without_extension)}.csv")
     prx_records = pl.from_pandas(prx_records_pd)
@@ -162,9 +162,9 @@ def build_metadata(input_files):
     ]
     try:
         prx_metadata["prx_git_commit_id"] = (
-                util.git_sha_of_this_package()
-                or util.git_sha_from_dist_info("prx")
-                or "unknown"
+            util.git_sha_of_this_package()
+            or util.git_sha_from_dist_info("prx")
+            or "unknown"
         )
     except git.exc.InvalidGitRepositoryError:
         prx_metadata["prx_git_commit_id"] = "not_a_git_repository"
@@ -172,7 +172,7 @@ def build_metadata(input_files):
 
 
 def check_assumptions(
-        rinex_3_obs_file,
+    rinex_3_obs_file,
 ):
     obs_header = georinex.rinexheader(rinex_3_obs_file)
     if "RCV CLOCK OFFS APPL" in obs_header.keys():
@@ -200,12 +200,12 @@ def warm_up_parser_cache(rinex_files):
 
 @util.timeit
 def build_records_levels_12(
-        rinex_3_obs_file,
-        rinex_3_ephemerides_files,
-        approximate_receiver_ecef_position_m,
-        prx_level,
-        model_tropo,
-        joblib_backend: str = "threading",
+    rinex_3_obs_file,
+    rinex_3_ephemerides_files,
+    approximate_receiver_ecef_position_m,
+    prx_level,
+    model_tropo,
+    joblib_backend: str = "threading",
 ):
     """
     Creates a flat_obs dataframe including columns for prx processing levels 1 and 2.
@@ -267,29 +267,37 @@ def build_records_levels_12(
     # the satellite's constellation time frame (integer-second aligned to the receiver time frame), plus the
     # satellite clock offset plus those small terms of a few tens of nanoseconds
     per_sat = per_sat.with_columns(
-        (pl.mean_horizontal(code_phase_columns) / constants.cGpsSpeedOfLight_mps).cast(
-            pl.Duration(time_unit="ms")).alias("tof_dtrx")
+        (
+            1e3
+            * (pl.mean_horizontal(code_phase_columns) / constants.cGpsSpeedOfLight_mps)
+        )
+        .cast(pl.Duration(time_unit="ms"))
+        .alias("tof_dtrx")
     )
     # As error terms are tens of nanoseconds here, and the receiver clock is integer-second aligned to GPST, we
     # already have times-of-emission that are integer-second aligned GPST here.
     per_sat = per_sat.with_columns(
-        (pl.col("time_of_reception_in_receiver_time") - pl.col("tof_dtrx")).alias("time_of_reception_in_receiver_time"))
+        (pl.col("time_of_reception_in_receiver_time") - pl.col("tof_dtrx")).alias(
+            "time_of_emission_isagpst"
+        )
+    )
 
-    flat_obs = flat_obs.merge(
-        per_sat[
+    flat_obs = flat_obs.join(
+        per_sat.select(
             [
                 "time_of_reception_in_receiver_time",
                 "satellite",
                 "time_of_emission_isagpst",
             ]
-        ],
+        ),
+        how="left",
         on=["time_of_reception_in_receiver_time", "satellite"],
     )
 
     # Build the query DataFrame we need to evaluate ephemerides
-    query = flat_obs[flat_obs["observation_type"].str.startswith("C")]
+    query = flat_obs.filter(pl.col("observation_type").str.starts_with("C"))
     query = query.rename(
-        columns={
+        {
             "observation_type": "signal",
             "satellite": "sv",
             "time_of_emission_isagpst": "query_time_isagpst",
@@ -302,61 +310,71 @@ def build_records_levels_12(
         # get year and doy from NAV filename
         year = int(file.name[12:16])
         doy = int(file.name[16:19])
-        day_query = query.loc[
-            (
-                    query.query_time_isagpst
-                    >= pd.Timestamp(year=year, month=1, day=1) + pd.Timedelta(days=doy - 1)
-            )
-            & (
-                    query.query_time_isagpst
-                    < pd.Timestamp(year=year, month=1, day=1) + pd.Timedelta(days=doy)
-            )
-            ]
+        day_query = query.filter(
+            pl.col("query_time_isagpst")
+            >= pd.Timestamp(year=year, month=1, day=1) + pd.Timedelta(days=doy - 1),
+            pl.col("query_time_isagpst")
+            < pd.Timestamp(year=year, month=1, day=1) + pd.Timedelta(days=doy),
+        ).to_pandas()
         if day_query.empty:
             continue
 
         log.info(f"Computing satellite states for {year}-{doy:03d}")
+        day_query["query_time_isagpst"] = day_query["query_time_isagpst"].astype(
+            "datetime64[ns]"
+        )
         sat_states_per_day.append(
-            rinex_evaluate.compute_parallel(
-                file,
-                day_query,
-                joblib_backend=joblib_backend,
+            pl.from_pandas(
+                rinex_evaluate.compute_parallel(
+                    file,
+                    day_query,
+                    joblib_backend=joblib_backend,
+                )
             )
         )
         if prx_level == 1:  # drop sat group delay
-            sat_states_per_day[-1] = sat_states_per_day[-1].drop(
-                columns=["sat_code_bias_m"]
-            )
-    sat_states = pd.concat(sat_states_per_day)
+            sat_states_per_day[-1] = sat_states_per_day[-1].drop(["sat_code_bias_m"])
+    sat_states = pl.concat(sat_states_per_day)
     sat_states = sat_states.rename(
-        columns={
+        {
             "sv": "satellite",
             "signal": "observation_type",
             "query_time_isagpst": "time_of_emission_isagpst",
         },
     )
-    (
-        sat_states["elevation_rad"],
-        sat_states["azimuth_rad"],
-    ) = util.compute_satellite_elevation_and_azimuth(
-        sat_states[["sat_pos_x_m", "sat_pos_y_m", "sat_pos_z_m"]].to_numpy(),
+    sat_elv_rad, sat_az_rad = util.compute_satellite_elevation_and_azimuth(
+        sat_states.select(["sat_pos_x_m", "sat_pos_y_m", "sat_pos_z_m"]).to_numpy(),
         approximate_receiver_ecef_position_m,
+    )
+    sat_states = sat_states.with_columns(
+        elevation_rad=sat_elv_rad,
+        azimuth_rad=sat_az_rad,
     )
 
     if prx_level == 2:
         # Compute anything else that is satellite-specific
-        sat_states["sagnac_effect_m"] = util.compute_sagnac_effect(
-            sat_states[["sat_pos_x_m", "sat_pos_y_m", "sat_pos_z_m"]].to_numpy(),
-            approximate_receiver_ecef_position_m,
-        )
-        sat_states["tropo_delay_m"] = atmo.compute_tropo_delay(
-            sat_states, flat_obs, approximate_receiver_ecef_position_m, model_tropo
+        sat_states = sat_states.with_columns(
+            sagnac_effect_m=util.compute_sagnac_effect(
+                sat_states.select(
+                    ["sat_pos_x_m", "sat_pos_y_m", "sat_pos_z_m"]
+                ).to_numpy(),
+                approximate_receiver_ecef_position_m,
+            ),
+            tropo_delay_m=atmo.compute_tropo_delay(
+                sat_states["elevation_rad"].to_numpy(),
+                sat_states["time_of_emission_isagpst"].to_numpy(),
+                approximate_receiver_ecef_position_m,
+                model_tropo,
+            ),
         )
 
     # Merge sat states into observation dataframe. Due to Galileo's FNAV/INAV ephemerides
     # being signal-specific, we merge on the code identifier here and not only the satellite
-    sat_states["code_id"] = sat_states["observation_type"].str[1:3]
-    flat_obs["code_id"] = flat_obs["observation_type"].str[1:3]
+    sat_states = sat_states.with_columns(
+        code_id=pl.col("observation_type").str.slice(1, 2)
+    )
+    flat_obs = flat_obs.with_columns(code_id=pl.col("observation_type").str.slice(1, 2))
+
     flat_obs = flat_obs.merge(
         sat_states.drop(columns=["observation_type"]),
         on=["satellite", "code_id", "time_of_emission_isagpst"],
@@ -374,7 +392,7 @@ def build_records_levels_12(
     glo_cdma = flat_obs[
         (flat_obs.satellite.str[0] == "R")
         & (flat_obs["observation_type"].str[1].astype(int) > 2)
-        ]
+    ]
     flat_obs.loc[glo_cdma.index, "frequency_slot"] = int(1)
 
     def assign_carrier_frequencies(flat_obs):
@@ -383,11 +401,11 @@ def build_records_levels_12(
         )[0]
         assignable = flat_obs.frequency_slot.notna()
         keys = (
-                flat_obs.satellite[assignable].str[0]
-                + "_L"
-                + flat_obs["observation_type"][assignable].str[1]
-                + "_"
-                + flat_obs.frequency_slot[assignable].astype(int).astype(str)
+            flat_obs.satellite[assignable].str[0]
+            + "_L"
+            + flat_obs["observation_type"][assignable].str[1]
+            + "_"
+            + flat_obs.frequency_slot[assignable].astype(int).astype(str)
         )
         flat_obs.loc[:, "carrier_frequency_hz"] = keys.map(freq_dict)
         return flat_obs
@@ -405,11 +423,11 @@ def build_records_levels_12(
 
 
 def build_records_level_3(
-        rinex_3_obs_file,
-        sp3_orbit_files,
-        atx_file,
-        approximate_receiver_ecef_position_m,
-        model_tropo,
+    rinex_3_obs_file,
+    sp3_orbit_files,
+    atx_file,
+    approximate_receiver_ecef_position_m,
+    model_tropo,
 ):
     """
     Creates a flat_obs dataframe including columns for prx processing level 3.
@@ -471,7 +489,7 @@ def build_records_level_3(
     # As error terms are tens of nanoseconds here, and the receiver clock is integer-second aligned to GPST, we
     # already have times-of-emission that are integer-second aligned GPST here.
     per_sat["time_of_emission_isagpst"] = (
-            per_sat["time_of_reception_in_receiver_time"] - tof_dtrx
+        per_sat["time_of_reception_in_receiver_time"] - tof_dtrx
     )
 
     flat_obs = flat_obs.merge(
@@ -506,14 +524,14 @@ def build_records_level_3(
         doy = int(file.name[15:18])
         day_query = query.loc[
             (
-                    query.query_time_isagpst
-                    >= pd.Timestamp(year=year, month=1, day=1) + pd.Timedelta(days=doy - 1)
+                query.query_time_isagpst
+                >= pd.Timestamp(year=year, month=1, day=1) + pd.Timedelta(days=doy - 1)
             )
             & (
-                    query.query_time_isagpst
-                    < pd.Timestamp(year=year, month=1, day=1) + pd.Timedelta(days=doy)
+                query.query_time_isagpst
+                < pd.Timestamp(year=year, month=1, day=1) + pd.Timedelta(days=doy)
             )
-            ]
+        ]
         if day_query.empty:
             continue
 
@@ -579,7 +597,7 @@ def build_records_level_3(
     glo_cdma = flat_obs[
         (flat_obs.satellite.str[0] == "R")
         & (flat_obs["observation_type"].str[1].astype(int) > 2)
-        ]
+    ]
     flat_obs.loc[glo_cdma.index, "frequency_slot"] = int(1)
 
     # set frequency slot to 1 for non-GLONASS satellites
@@ -591,11 +609,11 @@ def build_records_level_3(
         )[0]
         assignable = flat_obs.frequency_slot.notna()
         keys = (
-                flat_obs.satellite[assignable].str[0]
-                + "_L"
-                + flat_obs["observation_type"][assignable].str[1]
-                + "_"
-                + flat_obs.frequency_slot[assignable].astype(int).astype(str)
+            flat_obs.satellite[assignable].str[0]
+            + "_L"
+            + flat_obs["observation_type"][assignable].str[1]
+            + "_"
+            + flat_obs.frequency_slot[assignable].astype(int).astype(str)
         )
         flat_obs.loc[:, "carrier_frequency_hz"] = keys.map(freq_dict)
         return flat_obs
@@ -616,10 +634,10 @@ def build_records_level_3(
 
 @util.timeit
 def process(
-        observation_file_path: Path,
-        prx_level=2,
-        model_tropo="saastamoinen",
-        joblib_backend: str = "loky",
+    observation_file_path: Path,
+    prx_level=2,
+    model_tropo="saastamoinen",
+    joblib_backend: str = "loky",
 ):
     t0 = pd.Timestamp.now()
     # We expect a Path, but might get a string here:
@@ -688,7 +706,7 @@ if __name__ == "__main__":
     parser = argparse.ArgumentParser(
         prog="prx",
         description="prx processes RINEX observations, computes a few useful things such as satellite position, "
-                    "relativistic effects etc. and outputs everything to a text file in a convenient format.",
+        "relativistic effects etc. and outputs everything to a text file in a convenient format.",
         epilog="P.S. GNSS rules!",
     )
     parser.add_argument(

--- a/src/prx/test/benchmark.py
+++ b/src/prx/test/benchmark.py
@@ -39,7 +39,9 @@ def run_case(case: dict, ram: bool) -> pd.DataFrame:
         with memray.Tracker(memray_output, follow_fork=True):
             # Use multithreading here, memray does not track memory allocations in child processes with
             # joblib's "loky" backend. This likely makes prx slower, but we only care about memory allocation here.
-            process(observation_file_path=obs_file, joblib_backend="threading")
+            process(
+                observation_file_path=obs_file, prx_level=2, joblib_backend="threading"
+            )
         reader = memray.FileReader(memray_output)
         metadata = reader.metadata
         peak_ram_mb = metadata.peak_memory / 1024 / 1024


### PR DESCRIPTION
Converts `build_records_levels_12` to polars, making it about twice as fast.

Will convert `build_records_level_3` in a separate PR to keep this one at a manageable size. There is a lot of duplicate code in `build_records_level_3` that can be refactored out.

Running prx on a 3h 1Hz obs file, warm parser caches

This branch:
```
2026-05-27 11:13:34,648 [DEBUG] [prx.util]: Function build_records_levels_12 took 0 days 00:00:07.055290 to run.
2026-05-27 11:13:35,081 [INFO] [__main__]: Generated CSV prx file: /Users/janbolting/repositories/prx/debug/3h/benchmark_datasets/sweep/2.67h/202511140000_202511140310_911e2e81-1b6a-4516-b468-9ee24e77e8bc.obs_slice_2.67h.csv
2026-05-27 11:13:35,084 [DEBUG] [prx.util]: Function write_prx_file took 0 days 00:00:00.435810 to run.
2026-05-27 11:13:35,091 [DEBUG] [prx.util]: Function process took 0 days 00:00:07.537678 to run.
```

main
```
2026-05-27 11:15:35,785 [DEBUG] [prx.util]: Function build_records_levels_12 took 0 days 00:00:16.647501 to run.
2026-05-27 11:15:36,942 [INFO] [__main__]: Generated CSV prx file: <_io.TextIOWrapper name='/Users/janbolting/repositories/prx/debug/3h/benchmark_datasets/sweep/2.67h/202511140000_202511140310_911e2e81-1b6a-4516-b468-9ee24e77e8bc.obs_slice_2.67h.csv' mode='a' encoding='utf-8'>
2026-05-27 11:15:36,950 [DEBUG] [prx.util]: Function write_prx_file took 0 days 00:00:01.164316 to run.
2026-05-27 11:15:36,966 [DEBUG] [prx.util]: Function process took 0 days 00:00:17.865695 to run.
```

Peak memory is pretty much unchanged (main on the left)

<img width="1916" height="1049" alt="Screenshot 2026-05-27 at 11 19 47" src="https://github.com/user-attachments/assets/bcdfea45-203d-414e-8737-90972b1d99b1" />

