### PR TITLE
Allow benchmarking with warm parser caches

### DIFF
--- a/src/prx/rinex_nav/evaluate.py
+++ b/src/prx/rinex_nav/evaluate.py
@@ -1,4 +1,5 @@
 import logging
+from functools import lru_cache
 
 import pandas as pd
 import numpy as np
@@ -15,6 +16,7 @@ log = logging.getLogger(__name__)
 
 @timeit
 def parse_rinex_nav_file(rinex_file: Path):
+    @lru_cache
     @util.disk_cache.cache(ignore=["rinex_file_path"])
     def cached_load(rinex_file_path: Path, file_hash: str):
         try_repair_with_gfzrnx(rinex_file)

--- a/src/prx/rinex_obs/parser.py
+++ b/src/prx/rinex_obs/parser.py
@@ -1,5 +1,6 @@
 import logging
 import math
+from functools import lru_cache
 from pathlib import Path
 
 import numpy as np
@@ -133,6 +134,7 @@ def parse(file_path):
 
 @timeit
 def parse_rinex_obs_file(rinex_file_path: Path):
+    @lru_cache
     @disk_cache.cache(ignore=["rinex_file"])
     def parse_rinex_obs_file_cached(rinex_file: Path, file_hash: str):
         logger.info(f"Parsing {rinex_file} (hash {file_hash}) ...")

--- a/src/prx/rinex_obs/test/benchmark.py
+++ b/src/prx/rinex_obs/test/benchmark.py
@@ -12,7 +12,6 @@ import plotly.graph_objects as go
 import georinex
 
 
-
 def generate_inputs(
     n_steps: int = 10, root: Path = None, obs_file: Path = None
 ) -> list[dict]:

--- a/src/prx/rinex_obs/test/benchmark.py
+++ b/src/prx/rinex_obs/test/benchmark.py
@@ -1,4 +1,3 @@
-import shutil
 import subprocess
 import timeit
 
@@ -12,11 +11,10 @@ from plotly.subplots import make_subplots
 import plotly.graph_objects as go
 import georinex
 
-from prx.util import prx_src_directory
 
 
 def generate_inputs(
-    n_steps: int = 10, root: Path = None, obs_file: Path = None, nav_file: Path = None
+    n_steps: int = 10, root: Path = None, obs_file: Path = None
 ) -> list[dict]:
     if root is None:
         root = Path(__file__).parent / "benchmark_datasets"
@@ -25,12 +23,6 @@ def generate_inputs(
         obs_file = converters.anything_to_rinex_3(
             root / "datasets" / "TLSE00FRA_R_20220010000_01D_30S_MO.rnx.gz"
         )
-        nav_file = converters.anything_to_rinex_3(
-            prx_src_directory()
-            / "rinex_nav/test/datasets/BRDC00IGS_R_20220010000_01D_MN.zip"
-        )
-    else:
-        assert nav_file is not None, "Please provide both obs and nav files"
     sweep_dir = root / "sweep"
     sweep_dir.mkdir(exist_ok=True)
     times = georinex.obstime3(obs_file)
@@ -57,14 +49,10 @@ def generate_inputs(
             assert process_output.returncode == 0
             print(f"Created {slice_obs_file}")
         print(f"Adding {slice_obs_file} to the database ...")
-        slice_nav_file = slice_obs_file.parent / nav_file.name
-        if not slice_nav_file.exists():
-            shutil.copy(nav_file, slice_nav_file)
         cases.append(
             {
                 "epochs": (duration / pd.Timedelta("1s")) / float(header["INTERVAL"]),
                 "obs_file": slice_obs_file,
-                "nav_file": slice_nav_file,
             }
         )
     return cases

--- a/src/prx/test/benchmark.py
+++ b/src/prx/test/benchmark.py
@@ -8,9 +8,11 @@ from pathlib import Path
 from plotly.subplots import make_subplots
 import plotly.graph_objects as go
 
-from prx.main import process
+from prx.main import process, warm_up_parser_cache
 import cProfile
 import platform
+
+from prx.rinex_nav.nav_file_discovery import discover_or_download_auxiliary_files
 
 if platform.system() != "Windows":
     import memray
@@ -20,10 +22,16 @@ from prx.util import configure_logging, disk_cache
 logger = logging.getLogger(__name__)
 
 
-def run_case(case: dict, ram: bool) -> pd.DataFrame:
+def run_case(case: dict, ram: bool, warm_parser_cache: bool) -> pd.DataFrame:
     obs_file = Path(case["obs_file"])
-    # Purge caches, we're going for run time and peak RAM with a file prx has never seen before
-    disk_cache.clear()
+    # Fetch navigation files if necessary
+    if warm_parser_cache:
+        nav_files = discover_or_download_auxiliary_files(obs_file)[
+            "broadcast_ephemerides"
+        ]
+        warm_up_parser_cache(nav_files + [obs_file])
+    if not warm_parser_cache:
+        disk_cache.clear()
     p = cProfile.Profile()
     p.enable()
     process(observation_file_path=obs_file)
@@ -35,7 +43,8 @@ def run_case(case: dict, ram: bool) -> pd.DataFrame:
     if ram and (platform.system() != "Windows"):
         memray_output = obs_file.parent / f"{obs_file.stem}_memray.bin"
         memray_output.unlink(missing_ok=True)
-        disk_cache.clear()
+        if not warm_parser_cache:
+            disk_cache.clear()
         with memray.Tracker(memray_output, follow_fork=True):
             # Use multithreading here, memray does not track memory allocations in child processes with
             # joblib's "loky" backend. This likely makes prx slower, but we only care about memory allocation here.
@@ -70,16 +79,15 @@ def run_case(case: dict, ram: bool) -> pd.DataFrame:
     return df
 
 
-def main(ram: bool, obs_file: Path, nav_file: Path):
+def main(ram: bool, obs_file: Path, warm_parser_cache: bool):
     configure_logging("DEBUG")
 
     cases = generate_inputs(
         n_steps=10,
         obs_file=obs_file,
-        nav_file=nav_file,
         root=obs_file.parent / "benchmark_datasets" if obs_file is not None else None,
     )
-    df = pd.concat([run_case(case, ram) for case in cases])
+    df = pd.concat([run_case(case, ram, warm_parser_cache) for case in cases])
     fig = make_subplots(rows=2, cols=1)
     for (file, function), group in df.groupby(["file", "function"]):
         fig.add_trace(
@@ -111,7 +119,12 @@ def main(ram: bool, obs_file: Path, nav_file: Path):
 if __name__ == "__main__":
     arg_parser = argparse.ArgumentParser()
     arg_parser.add_argument("--ram", action="store_true")
+    arg_parser.add_argument(
+        "--warm-parser-cache",
+        action="store_true",
+        help="Provide this argument to have the benchmark parse observation and navigation files before profiling run time and RAM. "
+        "Gives a faster result because parser outputs are cached.",
+    )
     arg_parser.add_argument("--obs", type=Path, default=None)
-    arg_parser.add_argument("--nav", type=Path, default=None)
     args = arg_parser.parse_args()
-    main(ram=args.ram, obs_file=args.obs, nav_file=args.nav)
+    main(ram=args.ram, obs_file=args.obs, warm_parser_cache=args.warm_parser_cache)

--- a/src/prx/test/benchmark.py
+++ b/src/prx/test/benchmark.py
@@ -34,7 +34,8 @@ def run_case(case: dict, ram: bool, warm_parser_cache: bool) -> pd.DataFrame:
         disk_cache.clear()
     p = cProfile.Profile()
     p.enable()
-    process(observation_file_path=obs_file)
+    # cProfile does not profile subprocesses with joblib's loky backend, use threading
+    process(observation_file_path=obs_file, joblib_backend="threading")
     p.disable()
 
     # RAM
@@ -72,7 +73,7 @@ def run_case(case: dict, ram: bool, warm_parser_cache: bool) -> pd.DataFrame:
     df = df[["func", "tottime"]]
     df["function"] = df["func"].apply(lambda x: getattr(x, "co_name", None))
     df["file"] = df["func"].apply(lambda x: getattr(x, "co_filename", None))
-    df = df[df["function"].notnull() & df["file"].str.contains(r"prx[\\/]src[\\/]prx")]
+    df = df[df["function"].notnull() & df["file"].str.contains(r"prx/src/prx")]
     not_interesting = ["timeit_wrapper", "<genexpr>"]
     df = df[~df["function"].isin(not_interesting)]
     df = df.drop(columns=["func"])


### PR DESCRIPTION
Adds an argument to the prx top-level benchmark that makes the benchmark warm up parser caches before profiling run time and memory. Makes the benchmark itself much faster and just as informative, given that the nav and obs file parsers have their own benchmarks we can look at to see how they scale.

Also brings back in-RAM caching for parser caches.

Also removes passing nav file to the benchmark, it will be fetched from IGS anyways if the file name does not follow RINEX 3 conventions.

Example result: 

<img width="2541" height="1281" alt="Screenshot 2026-05-27 at 17 08 44" src="https://github.com/user-attachments/assets/020d9715-d46b-43f4-8ffe-0da167581497" />

