### PR TITLE
check which use of gfzrnx is done in header

### DIFF
--- a/src/prx/util.py
+++ b/src/prx/util.py
@@ -85,10 +85,19 @@ def timeit(func):
 
 @timeit
 def try_repair_with_gfzrnx(file):
-    with open(file) as f:
-        if "gfzrnx" in f.read():
-            logging.warning(f"File {file} already contains 'gfzrnx', skipping repair.")
-            return file
+    def _check_gfzrnx_processing(file):
+        with open(file) as f:
+            for line in f:
+                if "END OF HEADER" in line:
+                    break
+                if ("gfzrnx" in line) and ("FILE PROCESSING" in line):
+                    return True
+            return False
+
+    if _check_gfzrnx_processing(file):
+        logging.warning(f"File {file} already contains 'gfzrnx', skipping repair.")
+        return file
+
     tool_path = shutil.which("gfzrnx")
     if tool_path is None:
         logger.info(

--- a/src/prx/util.py
+++ b/src/prx/util.py
@@ -99,7 +99,7 @@ def try_repair_with_gfzrnx(file):
                 break
             n_line_read += 1
             if n_line_read > n_header_max:
-                # prevents reading the whole file is not a rinex file
+                # prevents reading the whole file if it is not a RINEX file
                 break
 
     if check_gfzrnx_processing:

--- a/src/prx/util.py
+++ b/src/prx/util.py
@@ -85,16 +85,24 @@ def timeit(func):
 
 @timeit
 def try_repair_with_gfzrnx(file):
-    def _check_gfzrnx_processing(file):
-        with open(file) as f:
-            for line in f:
-                if "END OF HEADER" in line:
-                    break
-                if ("gfzrnx" in line) and ("FILE PROCESSING" in line):
-                    return True
-            return False
+    # check if file has been processed by gfzrnx
+    check_gfzrnx_processing = False
+    n_line_read = 0
+    # assume that RINEX header is less than 1000 lines
+    n_header_max = 1000
+    with open(file) as f:
+        for line in f:
+            if "END OF HEADER" in line:
+                break
+            if ("gfzrnx" in line) and ("FILE PROCESSING" in line):
+                check_gfzrnx_processing = True
+                break
+            n_line_read += 1
+            if n_line_read > n_header_max:
+                # prevents reading the whole file is not a rinex file
+                break
 
-    if _check_gfzrnx_processing(file):
+    if check_gfzrnx_processing:
         logging.warning(f"File {file} already contains 'gfzrnx', skipping repair.")
         return file
 


### PR DESCRIPTION
closes #235 

Check that both "gfzrnx" and "FILE PROCESSING" are in the header to decide whether to reprocess a file with gfzrnx.

This is due because some old files used gfzrnx to merge NAV files, but not check/repair them.