### PR TITLE
fix remote directory for old BIA files

### DIFF
--- a/src/prx/precise_corrections/bia/bia_file_discovery.py
+++ b/src/prx/precise_corrections/bia/bia_file_discovery.py
@@ -55,7 +55,10 @@ def check_online_availability(year: int, doy: int, analysis_center: str) -> Path
     gps_week, _ = util.timestamp_to_gps_week_and_dow(
         pd.Timestamp(year=year, month=1, day=1) + pd.Timedelta(days=doy - 1)
     )
-    remote_folder = f"gnss/products/{gps_week}"
+    if gps_week > 2237:
+        remote_folder = f"/gnss/products/{gps_week}"
+    else:
+        remote_folder = f"/gnss/products/{gps_week}/mgex"
     file = build_bia_file_name(year, doy, analysis_center)
     ftp = ftplib.FTP(server)
     ftp.login()
@@ -76,7 +79,10 @@ def try_downloading_bia_ftp(year: int, doy: int, analysis_center: str) -> Path |
     gps_week, _ = util.timestamp_to_gps_week_and_dow(
         pd.Timestamp(year=year, month=1, day=1) + pd.Timedelta(days=doy - 1)
     )
-    remote_folder = f"gnss/products/{gps_week}"
+    if gps_week > 2237:
+        remote_folder = f"/gnss/products/{gps_week}"
+    else:
+        remote_folder = f"/gnss/products/{gps_week}/mgex"
     ftp_file = f"ftp://{server}/{remote_folder}/{file}"
     local_file = bia_file_folder(year, doy) / build_bia_file_name(
         year, doy, analysis_center

--- a/src/prx/precise_corrections/sp3/sp3_file_discovery.py
+++ b/src/prx/precise_corrections/sp3/sp3_file_discovery.py
@@ -147,6 +147,7 @@ def get_sp3_files(
     analysis_center: str,
     db_folder=sp3_file_database_folder(),
 ) -> tuple[list[Path | None], list[Path | None]]:
+    analysis_center = analysis_center.upper()
     sp3_orb_files = []
     sp3_clk_files = []
     date = mid_day_start


### PR DESCRIPTION
Depending on the GPS week, the remote directory on IGS FTP servers has a different address. 